### PR TITLE
Add admin end points

### DIFF
--- a/app-backend/src/controllers/admin.controller.js
+++ b/app-backend/src/controllers/admin.controller.js
@@ -1,0 +1,82 @@
+import User from '../models/User.js';
+import Shift from '../models/Shift.js';  // import your Shift model
+import jwt from 'jsonwebtoken';
+
+/**
+ * Generate JWT token for a user
+ * @param {Object} user
+ * @returns {string} JWT token
+ */
+const generateToken = (user) => {
+  return jwt.sign(
+    { id: user._id, role: user.role },
+    process.env.JWT_SECRET,
+    { expiresIn: '1h' }
+  );
+};
+
+/**
+ * @desc Admin login
+ * @route POST /api/v1/admin/login
+ * @access Public
+ */
+export const adminLogin = async (req, res) => {
+  const { email, password } = req.body;
+
+  try {
+    const user = await User.findOne({ email }).select('+password');
+    if (!user || user.role !== 'admin') {
+      return res.status(403).json({ message: 'Access denied. Not an admin user.' });
+    }
+
+    const isMatch = await user.matchPassword(password);
+    if (!isMatch) return res.status(401).json({ message: 'Invalid credentials' });
+
+    user.lastLogin = new Date();
+    await user.save();
+
+    const token = generateToken(user);
+
+    res.status(200).json({
+      token,
+      id: user._id,
+      name: user.name,
+      role: user.role,
+    });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+/**
+ * @desc Get all users (admin only)
+ * @route GET /api/v1/admin/users
+ * @access Admin only
+ */
+export const getAllUsers = async (req, res) => {
+  try {
+    // Fetch all users, exclude passwords for security
+    const users = await User.find().select('-password');
+    res.status(200).json({ users });
+  } catch (error) {
+    res.status(500).json({ message: 'Failed to retrieve users', error: error.message });
+  }
+};
+
+/**
+ * @desc Get all shifts (admin only)
+ * @route GET /api/v1/admin/shifts
+ * @access Admin only
+ */
+export const getAllShifts = async (req, res) => {
+  try {
+    // Fetch all shifts with user references populated for clarity
+    const shifts = await Shift.find()
+      .populate('createdBy', 'name email role')  // populate employer info
+      .populate('acceptedBy', 'name email role'); // populate guard info
+
+    res.status(200).json({ shifts });
+  } catch (error) {
+    res.status(500).json({ message: 'Failed to retrieve shifts', error: error.message });
+  }
+};

--- a/app-backend/src/routes/admin.routes.js
+++ b/app-backend/src/routes/admin.routes.js
@@ -1,0 +1,79 @@
+// routes/admin.routes.js
+import express from 'express';
+import { adminLogin, getAllUsers, getAllShifts } from '../controllers/admin.controller.js';
+import auth from '../middleware/auth.js';
+import { adminOnly } from '../middleware/role.js';
+
+const router = express.Router();
+
+/**
+ * @swagger
+ * tags:
+ *   name: Admin
+ *   description: Admin-specific operations
+ */
+
+/**
+ * @swagger
+ * /api/v1/admin/login:
+ *   post:
+ *     summary: Admin login
+ *     tags: [Admin]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - email
+ *               - password
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: JWT token returned on successful admin login
+ *       403:
+ *         description: Access denied (not an admin)
+ *       401:
+ *         description: Invalid credentials
+ */
+router.post('/login', adminLogin);
+
+/**
+ * @swagger
+ * /api/v1/admin/users:
+ *   get:
+ *     summary: Get all users (Admin only)
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Placeholder list of users
+ *       403:
+ *         description: Forbidden
+ */
+router.get('/users', auth, adminOnly, getAllUsers);
+
+/**
+ * @swagger
+ * /api/v1/admin/shifts:
+ *   get:
+ *     summary: Get all shifts (Admin only)
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Placeholder list of shifts
+ *       403:
+ *         description: Forbidden
+ */
+router.get('/shifts', auth, adminOnly, getAllShifts);
+
+export default router;

--- a/app-backend/src/routes/index.js
+++ b/app-backend/src/routes/index.js
@@ -3,12 +3,12 @@ import healthRoutes from './health.routes.js';
 import authRoutes   from './auth.routes.js';
 import shiftRoutes  from './shift.routes.js';
 import messageRoutes from './message.routes.js';
-
+import adminRoutes from './admin.routes.js';
 const router = Router();
 
 router.use('/health', healthRoutes);
 router.use('/auth',   authRoutes);
 router.use('/shifts', shiftRoutes);
 router.use ('/messages', messageRoutes);
-
+router.use('/admin', adminRoutes);
 export default router;


### PR DESCRIPTION
Set up a separate login route and access flow for admin users, enabling stricter control and dashboard separation.

Expected Outcome:
Admin users can log in separately and access restricted admin endpoints using their own JWT.