### PR TITLE
change default server port from 3000 to 5000

### DIFF
--- a/app-backend/server.js
+++ b/app-backend/server.js
@@ -5,7 +5,7 @@ import app from './src/app.js';
 
 dotenv.config();
 
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 5000;
 
 const startServer = async () => {
   try {


### PR DESCRIPTION
## Summary
Changed the default backend server port from 3000 to 5000 in `server.js`.

## Reason for Change
Mentor Akshat requested this update because port 3000 is already being used by the Employer Panel frontend. 
Running both backend and frontend on the same port caused crashes/conflicts during development. 
By defaulting backend to port 5000, the services can run simultaneously without issues.

## Changes Made
- Updated `server.js`:
  - `const PORT = process.env.PORT || 3000;`
  - → `const PORT = process.env.PORT || 5000;`

## Testing
- Ran `docker compose up --build -d` and confirmed backend starts on port 5000.
- Verified Employer Panel frontend (port 3000) and backend (port 5000) no longer conflict.