### PR TITLE
Added shift history

### DIFF
--- a/app-backend/src/routes/shift.routes.js
+++ b/app-backend/src/routes/shift.routes.js
@@ -8,6 +8,7 @@ import {
   getMyShifts,
   rateShift,
   listAvailableShifts, // dynamic by role
+  getShiftHistory,
 } from '../controllers/shift.controller.js';
 
 const router = express.Router();
@@ -297,5 +298,25 @@ router
 router
   .route('/:id/rate')
   .patch(protect, authorizeRole('guard', 'employer'), rateShift);
+
+/**
+ * @swagger
+ * /api/v1/shifts/history:
+ *   get:
+ *     summary: Get shift history (Guard/Employer only)
+ *     description: |
+ *       • Guard → all past/completed shifts the guard worked on.  
+ *       • Employer → all past/completed shifts the employer created.  
+ *     tags: [Shifts]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200: { description: List of completed shifts for the user }
+ *       401: { description: Unauthorized }
+ *       403: { description: Forbidden }
+ */
+router
+  .route('/history')
+  .get(protect, authorizeRole('guard', 'employer'), getShiftHistory);
 
 export default router;


### PR DESCRIPTION
Add GET /shifts/history route.

If role is Guard → return completed shifts assigned to them.

If role is Employer → return posted shifts with status = "completed".

Use auth.js and role.js to restrict access.

Add appropriate indexing on status and date.
<img width="1512" height="834" alt="Screenshot 2025-09-05 at 12 38 14 pm" src="https://github.com/user-attachments/assets/c55376d9-5f8d-4323-b710-4fd41c1b358a" />

