### PR TITLE
License Status Popup on OTP Verification

### DIFF
--- a/guard_app/src/screen/loginscreen.tsx
+++ b/guard_app/src/screen/loginscreen.tsx
@@ -1,4 +1,3 @@
-// screens/LoginScreen.tsx
 import React, { useState } from 'react';
 import {
   View,
@@ -12,22 +11,20 @@ import {
   Alert,
 } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-
-// Added for token storage and login API
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { login as apiLogin, verifyOtp as apiVerifyOtp } from '../api/auth';
+import {
+  login as apiLogin,
+  verifyOtp as apiVerifyOtp,
+  getMe, // Added to fetch current user's profile
+} from '../api/auth';
 
 export default function LoginScreen({ navigation }: any) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPass, setShowPass] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  // State for OTP mode and code
   const [otpMode, setOtpMode] = useState(false);
   const [otp, setOtp] = useState('');
-
-  // State for loading indicator
   const [submitting, setSubmitting] = useState(false);
 
   const validate = () => {
@@ -38,12 +35,10 @@ export default function LoginScreen({ navigation }: any) {
     return null;
   };
 
-  // Reset stack and go to AppTabs
   const goToApp = async () => {
     navigation.reset({ index: 0, routes: [{ name: 'AppTabs' as never }] });
   };
 
-  // Now handles API login and OTP fallback
   const handleLogin = async () => {
     const msg = validate();
     if (msg) {
@@ -53,13 +48,13 @@ export default function LoginScreen({ navigation }: any) {
     }
     try {
       setSubmitting(true);
-      const res = await apiLogin({ email: email.trim().toLowerCase(), password });
+      const res = await apiLogin({ email: email.trim(), password });
 
       if (res.token) {
         await AsyncStorage.setItem('auth_token', res.token); // Save token
-        await goToApp();
+        await goToApp(); // Direct login
       } else {
-        setOtpMode(true); // Trigger OTP screen
+        setOtpMode(true); // Switch to OTP input
         Alert.alert('OTP required', 'Please enter the code sent to your email.');
       }
     } catch (e: any) {
@@ -71,7 +66,7 @@ export default function LoginScreen({ navigation }: any) {
     }
   };
 
-  // OTP verification handler
+  // OTP verification logic with license status check
   const handleVerifyOtp = async () => {
     if (!otp.trim()) {
       Alert.alert('OTP required', 'Enter your OTP code.');
@@ -79,11 +74,44 @@ export default function LoginScreen({ navigation }: any) {
     }
     try {
       setSubmitting(true);
-      const res = await apiVerifyOtp({ email: email.trim().toLowerCase(), otp: otp.trim() });
+      const res = await apiVerifyOtp({ email: email.trim(), otp: otp.trim() });
 
-      if (!res.token) throw new Error('No token returned');
-      await AsyncStorage.setItem('auth_token', res.token); // Save verified token
-      await goToApp();
+      const token = res.token;
+      if (!token) throw new Error('No token returned');
+
+      // Save token
+      await AsyncStorage.setItem('auth_token', token);
+
+      // Fetch user profile to check license status
+      const user = await getMe();
+      const license = user?.license;
+
+      if (!license) {
+        Alert.alert('Error', 'License info not found.');
+        return;
+      }
+
+      const status = license.status;
+      const reason = license.rejectionReason;
+
+      if (status === 'verified') {
+        // If verified, go to app
+        await goToApp();
+      } else if (status === 'pending') {
+        // If pending, show info message
+        Alert.alert(
+          'License Pending',
+          'Your license is currently under review. You will be notified once it is verified.'
+        );
+      } else if (status === 'rejected') {
+        // If rejected, show rejection reason
+        Alert.alert(
+          'License Rejected',
+          `Your license was rejected.\n\nReason: ${reason || 'No reason provided'}.\n\nPlease check your email for more details.`
+        );
+      } else {
+        Alert.alert('Unknown License Status', `Status: ${status}`);
+      }
     } catch (e: any) {
       const apiMsg = e?.response?.data?.message ?? e?.message ?? 'Invalid or expired code';
       setError(apiMsg);
@@ -100,6 +128,7 @@ export default function LoginScreen({ navigation }: any) {
         <Text style={styles.subtitle}>Login with your email and password</Text>
         {error ? <Text style={styles.error}>{error}</Text> : null}
 
+        {/* Email input */}
         <Text style={styles.label}>Email*</Text>
         <View style={styles.inputWrap}>
           <TextInput
@@ -112,7 +141,7 @@ export default function LoginScreen({ navigation }: any) {
             onChangeText={(t) => {
               setEmail(t);
               if (otpMode) {
-                setOtpMode(false); // reset OTP if email changes
+                setOtpMode(false);
                 setOtp('');
               }
               if (error) setError(null);
@@ -122,6 +151,7 @@ export default function LoginScreen({ navigation }: any) {
           />
         </View>
 
+        {/* Password input */}
         <Text style={[styles.label, styles.mt16]}>Password*</Text>
         <View style={styles.inputWrap}>
           <TextInput
@@ -140,19 +170,21 @@ export default function LoginScreen({ navigation }: any) {
             onPress={() => setShowPass((s) => !s)}
             style={styles.eye}
             hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
-            accessibilityRole="button"
-            accessibilityLabel={showPass ? 'Hide password' : 'Show password'}
           >
             <MaterialCommunityIcons name={showPass ? 'eye-off-outline' : 'eye-outline'} size={22} color="#6B7280" />
           </TouchableOpacity>
         </View>
 
-        {/* Button now shows loading state */}
-        <TouchableOpacity style={[styles.button, submitting && { opacity: 0.6 }]} onPress={handleLogin} disabled={submitting}>
+        {/* Login button */}
+        <TouchableOpacity
+          style={[styles.button, submitting && { opacity: 0.6 }]}
+          onPress={handleLogin}
+          disabled={submitting}
+        >
           <Text style={styles.buttonText}>{submitting ? 'Logging in...' : 'Login'}</Text>
         </TouchableOpacity>
 
-        {/* OTP field shown only if triggered */}
+        {/* OTP input */}
         {otpMode && (
           <>
             <Text style={styles.label}>Enter OTP*</Text>
@@ -188,11 +220,11 @@ export default function LoginScreen({ navigation }: any) {
   );
 }
 
+// Styles
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: '#F5F6FA' },
   container: { flex: 1, paddingHorizontal: 24, paddingTop: 80 },
   logo: { width: 150, height: 150, alignSelf: 'center', resizeMode: 'contain' },
-  title: { fontSize: 26, fontWeight: '700', textAlign: 'center', color: '#1F2937' },
   subtitle: { marginTop: 6, textAlign: 'center', color: '#6B7280' },
   error: { color: '#B00020', textAlign: 'center', marginTop: 12, fontWeight: '600' },
   label: { marginTop: 24, marginBottom: 8, color: '#111827', fontWeight: '600' },
@@ -214,7 +246,14 @@ const styles = StyleSheet.create({
   input: { fontSize: 16, color: '#111827' },
   padRight: { paddingRight: 44 },
   eye: { position: 'absolute', right: 14, height: 56, justifyContent: 'center' },
-  button: { marginTop: 28, height: 58, borderRadius: 999, backgroundColor: '#274289', alignItems: 'center', justifyContent: 'center' },
+  button: {
+    marginTop: 28,
+    height: 58,
+    borderRadius: 999,
+    backgroundColor: '#274289',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   buttonText: { color: '#FFFFFF', fontSize: 16, fontWeight: '600' },
   footerText: { textAlign: 'center', marginTop: 22, color: '#111827' },
   footerLink: { fontWeight: '700' },


### PR DESCRIPTION
## Summary
This PR introduces a new flow in the `LoginScreen` to handle guard license status **after OTP verification**. Upon successful OTP validation, the app now fetches the user's profile (`/users/me`) and performs conditional navigation based on their license status:

- **Verified**: Navigates directly to the Home screen.
<img width="330" height="713" alt="License Verified" src="https://github.com/user-attachments/assets/30412d4e-17f5-47a1-a03d-06134e7abb08" />
<img width="1425" height="860" alt="Verified Backend" src="https://github.com/user-attachments/assets/93d3bc71-7703-41f8-af65-201ead4e0956" />

- **Pending**: Shows an alert indicating the license is under review.
<img width="328" height="705" alt="License Pending" src="https://github.com/user-attachments/assets/419e4f42-4c4c-401a-b3ca-ffbbe25e634d" />


- **Rejected**: Displays an alert with the rejection reason (fetched from `license.rejectionReason` field), and instructs the guard to check their email for further steps.
<img width="332" height="706" alt="License Reject" src="https://github.com/user-attachments/assets/fb7d597a-a979-471f-b17c-2358bdfe813e" />
<img width="1434" height="861" alt="Reject backend" src="https://github.com/user-attachments/assets/5727cf79-432d-41c7-b8fa-3b3b8a511b19" />


## Why This Change?
To ensure guards with rejected or unverified licenses do not access the app, and to improve user experience by showing appropriate messages and guidance based on their verification status.

## How to Test
1. Log in using a guard account that requires OTP.
2. After OTP verification:
   - If license is `verified`, you will be taken to the Home screen.
   - If `pending`, you’ll see an alert: "Your license is under review."
   - If `rejected`, you’ll see the reason and be asked to check your email.

## Backend Dependency
- Endpoint used: `GET /api/v1/users/me`
- Expects `license.status` and `license.rejectionReason` to be returned from the backend

---