### PR TITLE
Refactor inline styles in TimeSheetsScreen

### DIFF
--- a/guard_app/src/screen/TimeSheetsScreen.tsx
+++ b/guard_app/src/screen/TimeSheetsScreen.tsx
@@ -128,7 +128,7 @@ export default function TimesheetsScreen() {
         data={items}
         keyExtractor={(item) => item._id}
         renderItem={renderItem}
-        contentContainerStyle={{ padding: 16 }}
+        contentContainerStyle={s.listContainer}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
         ListEmptyComponent={<Text style={s.empty}>No timesheet records yet.</Text>}
       />
@@ -241,4 +241,9 @@ const getStyles = (colors: AppColors) =>
     badgeTextWarn: {
       color: colors.link,
     },
+
+    listContainer: {
+      padding: 16,
+    },
   });
+  

--- a/guard_app/src/screen/TimeSheetsScreen.tsx
+++ b/guard_app/src/screen/TimeSheetsScreen.tsx
@@ -246,4 +246,3 @@ const getStyles = (colors: AppColors) =>
       padding: 16,
     },
   });
-  


### PR DESCRIPTION
Moved the inline padding style from FlatList into the StyleSheet by creating a listContainer style.

Applied the new style using contentContainerStyle to replace the inline style.Style

<img width="940" height="251" alt="image" src="https://github.com/user-attachments/assets/f15fda31-80a5-45bc-a936-f2e36b578649" />
<img width="940" height="349" alt="image" src="https://github.com/user-attachments/assets/6f61ae09-fc2a-479c-ac3f-201514c56ed4" />
