### PR TITLE
Fix RBAC misconfiguration for /users/guards endpoint (Phase 1)

### DIFF
--- a/app-backend/src/routes/user.routes.js
+++ b/app-backend/src/routes/user.routes.js
@@ -252,23 +252,25 @@ router.delete(
  * @swagger
  * /api/v1/users/guards:
  *   get:
- *     summary: Get all guards (Admin + Employee only)
+ *     summary: Get all guards (Admin only)
  *     tags: [Users]
  *     security:
  *       - bearerAuth: []
  *     responses:
  *       200:
- *         description: Successfully retrieved all guards.
+ *         description: Successfully retrieved all guards (admin access only).
  *       401:
  *         description: Unauthorized
  *       403:
  *         description: Forbidden
  */
+// TODO: Enable employer access with scoped filtering (guards by organisation)
+// Do not expose this endpoint to employers until proper RBAC + filtering is implemented
 router.get(
   '/guards',
   auth,
   loadUser,
-  authorizeRoles(ROLES.ADMIN, ROLES.EMPLOYEE),
+  authorizeRoles(ROLES.ADMIN),
   authorizePermissions('user:read'),
   getAllGuards
 );


### PR DESCRIPTION
Quick PR addresses an RBAC issue in the `/api/v1/users/guards` endpoint.

### Issue
- Route referenced invalid role `EMPLOYEE`
- Employers were receiving 403 errors
- Endpoint currently returns unscoped guard data

### Fix (Phase 1)
- Removed invalid role `EMPLOYEE`
- Restricted endpoint to `ADMIN` only for now
- Added TODO for scoped employer access

### Notes
Employer access will require:
- proper RBAC permission design
- organisation-based filtering in the service layer

This will be handled in a follow-up task.

<img width="1183" height="826" alt="users_guards_200" src="https://github.com/user-attachments/assets/5ef31e2e-0445-493d-9677-38468391e6b5" />