### PR TITLE
feat: add logout dropdown in header

### DIFF
--- a/app-frontend/employer-panel/src/components/Header.js
+++ b/app-frontend/employer-panel/src/components/Header.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import CompanyLogo from './company_logo.svg';
 import ProfilePicPlaceHolder from './ProfilePicPlaceHolder.svg';
@@ -6,6 +6,7 @@ import NotificationsPopup from '../pages/NotificationsPopup';
 
 export default function Header() {
   const navigate = useNavigate();
+  const [showMenu, setShowMenu] = useState(false);
 
   const headerStyle = {
     backgroundColor: '#072261',
@@ -36,13 +37,21 @@ export default function Header() {
     navigate(token ? '/employer-dashboard' : '/login');
   };
 
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('userRole');
+    navigate('/login');
+  };
+
   return (
     <div style={headerStyle}>
+      {/* Logo */}
       <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
         <img src={CompanyLogo} alt="Company Logo" style={{ height: '66px' }} />
         <div style={{ fontWeight: '600', fontSize: '24px' }}>Secure Shift</div>
       </div>
 
+      {/* Navigation */}
       <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
         <div onClick={handleHomeClick} style={navButtonStyle}>
           Home
@@ -68,12 +77,49 @@ export default function Header() {
 
         <NotificationsPopup />
 
-        <div onClick={() => navigate('/company-profile')} style={{ cursor: 'pointer' }}>
-          <img
-            src={ProfilePicPlaceHolder}
-            alt="Profile"
-            style={{ height: '60px', marginLeft: '10px' }}
-          />
+        {/* Avatar + Dropdown */}
+        <div style={{ position: 'relative' }}>
+          <div onClick={() => setShowMenu(!showMenu)} style={{ cursor: 'pointer' }}>
+            <img
+              src={ProfilePicPlaceHolder}
+              alt="Profile"
+              style={{ height: '60px', marginLeft: '10px' }}
+            />
+          </div>
+
+          {showMenu && (
+            <div
+              style={{
+                position: 'absolute',
+                right: 0,
+                top: '70px',
+                background: 'white',
+                color: 'black',
+                borderRadius: '8px',
+                padding: '10px',
+                boxShadow: '0 4px 10px rgba(0,0,0,0.2)',
+                minWidth: '140px',
+                zIndex: 1000,
+              }}
+            >
+              <div
+                style={{ padding: '8px', cursor: 'pointer' }}
+                onClick={() => {
+                  navigate('/company-profile');
+                  setShowMenu(false);
+                }}
+              >
+                Profile
+              </div>
+
+              <div
+                style={{ padding: '8px', cursor: 'pointer', color: 'red' }}
+                onClick={handleLogout}
+              >
+                Logout
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Added logout functionality to the Employer Panel header by creating a dropdown menu on avatar click. The dropdown includes options for navigating to the profile page and logging out. Logging out clears the user session from local storage and redirects the user to the login page.

Changes Made
1. Added avatar dropdown menu in Header.js
2. Added logout option
3. Added profile navigation option
4. Cleared authentication data from local storage on logout
5. Redirected user to login page after logout

Testing
1. Verified dropdown opens on avatar click
2. Verified profile option works
3. Verified logout redirects to login
4. Verified local storage is cleared after logout