### PR TITLE
Jamespowis/fix/read notification

### DIFF
--- a/app-frontend/employer-panel/src/pages/NotificationsPopup.js
+++ b/app-frontend/employer-panel/src/pages/NotificationsPopup.js
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import NotificationIcon from '../components/NotificationIcon.svg';
 import http from '../lib/http';
 
-const POLL_INTERVAL_MS = 30_000;
+const POLL_INTERVAL_MS = 15_000;
 
 export default function NotificationsPopup() {
   const navigate = useNavigate();
@@ -84,7 +84,7 @@ export default function NotificationsPopup() {
     const init = async () => {
       const existing = await loadNotifications();
       seedSeen(existing);
-      pollShifts();
+      await pollShifts();
     };
     init();
     const interval = setInterval(pollShifts, POLL_INTERVAL_MS);

--- a/app-frontend/employer-panel/src/pages/NotificationsPopup.js
+++ b/app-frontend/employer-panel/src/pages/NotificationsPopup.js
@@ -3,205 +3,187 @@ import { useNavigate } from 'react-router-dom';
 import NotificationIcon from '../components/NotificationIcon.svg';
 import http from '../lib/http';
 
-const POLL_INTERVAL_MS = 30_000;
+const POLL_INTERVAL = 30_000;
 
 export default function NotificationsPopup() {
   const navigate = useNavigate();
   const [notifications, setNotifications] = useState([]);
-  const [showPopup, setShowPopup] = useState(false);
+  const [open, setOpen] = useState(false);
   const popupRef = useRef(null);
 
-  // Tracks applicant IDs we've already seen per shift,
-  // so we only notify on genuinely new applications
-  const prevApplicantsRef = useRef({});
+  // keyed by shiftId, tracks which applicant IDs we've already notified about
+  const seenApplicants = useRef({});
 
-  // ------------------------------------------------------------------
-  // Polling — diffs current applicants against what we last saw
-  // ------------------------------------------------------------------
-  const fetchAndDiffShifts = async () => {
+  const loadNotifications = async () => {
     try {
-      const response = await http.get('/shifts?withApplicantsOnly=true');
-      const shifts = (response.data.items || []).filter(
-        (s) => s.status === 'open' || s.status === 'applied'
+      const res = await http.get('/notifications');
+      const data = res.data.notifications || [];
+      setNotifications(data);
+      return data;
+    } catch (err) {
+      console.error('Failed to load notifications:', err);
+      return [];
+    }
+  };
+
+  // Seed seenApplicants from whatever's already in the DB so we don't
+  // re-create notifications on every page load
+  const seedSeen = (existing) => {
+    for (const n of existing) {
+      const { shiftId, applicantId } = n.data || {};
+      if (!shiftId || !applicantId) continue;
+      const key = String(shiftId);
+      if (!seenApplicants.current[key]) seenApplicants.current[key] = [];
+      const id = String(applicantId);
+      if (!seenApplicants.current[key].includes(id)) {
+        seenApplicants.current[key].push(id);
+      }
+    }
+  };
+
+  const pollShifts = async () => {
+    try {
+      const res = await http.get('/shifts?withApplicantsOnly=true');
+      const shifts = (res.data.items || []).filter(s =>
+        ['open', 'applied', 'assigned'].includes(s.status)
       );
 
-      const newNotifications = [];
-
-      shifts.forEach((shift) => {
+      for (const shift of shifts) {
         const applicants = shift.applicants || [];
-        const prevIds = prevApplicantsRef.current[shift._id] || [];
+        const seen = seenApplicants.current[shift._id] || [];
+        const newOnes = applicants.filter(a => !seen.includes(String(a._id)));
 
-        applicants
-          .filter((a) => !prevIds.includes(a._id))
-          .forEach((applicant) => {
-            newNotifications.push({
-              id: `${shift._id}-${applicant._id}`,
-              shiftId: shift._id,
-              shiftTitle: shift.title,
-              shiftDate: shift.date,
-              shiftStartTime: shift.startTime,
-              shiftEndTime: shift.endTime,
-              guardName: applicant.name,
-              isRead: false,
-              receivedAt: new Date().toISOString(),
+        for (const applicant of newOnes) {
+          try {
+            const date = new Date(shift.date).toLocaleDateString('en-AU', {
+              weekday: 'short', day: 'numeric', month: 'short',
             });
-          });
+            await http.post('/notifications', {
+              userId: shift.createdBy._id || shift.createdBy,
+              type: 'SHIFT_APPLIED',
+              title: `New application — ${shift.title}`,
+              message: `${applicant.name} has applied for your shift on ${date} (${shift.startTime} – ${shift.endTime})`,
+              data: { shiftId: shift._id, applicantId: applicant._id },
+            });
+          } catch (err) {
+            console.error('Failed to save notification:', err);
+          }
+        }
 
-        prevApplicantsRef.current[shift._id] = applicants.map((a) => a._id);
-      });
-
-      if (newNotifications.length > 0) {
-        setNotifications((prev) => [...newNotifications, ...prev]);
+        // Update seen list regardless of whether the POST succeeded
+        seenApplicants.current[shift._id] = applicants.map(a => String(a._id));
       }
+
+      await loadNotifications();
     } catch (err) {
-      console.error('NotificationsPopup: failed to fetch shifts', err);
+      console.error('Failed to poll shifts:', err);
     }
   };
 
   useEffect(() => {
-    fetchAndDiffShifts();
-    const interval = setInterval(fetchAndDiffShifts, POLL_INTERVAL_MS);
+    const init = async () => {
+      const existing = await loadNotifications();
+      seedSeen(existing);
+      pollShifts();
+    };
+    init();
+    const interval = setInterval(pollShifts, POLL_INTERVAL);
     return () => clearInterval(interval);
   }, []);
 
-  // Close popup when clicking outside
   useEffect(() => {
     const handleClickOutside = (e) => {
       if (popupRef.current && !popupRef.current.contains(e.target)) {
-        setShowPopup(false);
+        setOpen(false);
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  // ------------------------------------------------------------------
-  // Handlers
-  // ------------------------------------------------------------------
-  const unreadCount = notifications.filter((n) => !n.isRead).length;
-
-  const markAllAsRead = () => setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
-
-  const handleBellClick = () => {
-    setShowPopup((prev) => !prev);
-    // Mark as read when user opens the panel
-    if (!showPopup && unreadCount > 0) markAllAsRead();
-  };
-
-  const handleNotificationClick = () => {
+  const handleNotificationClick = async (n) => {
+    if (!n.isRead) {
+      try {
+        await http.patch(`/notifications/${n._id}/read`);
+        setNotifications(prev =>
+          prev.map(item => item._id === n._id ? { ...item, isRead: true } : item)
+        );
+      } catch (err) {
+        console.error('Failed to mark as read:', err);
+      }
+    }
     navigate('/manage-shift');
-    setShowPopup(false);
+    setOpen(false);
   };
 
-  // ------------------------------------------------------------------
-  // Styles (inline to preserve positioning behaviour with parent header)
-  // ------------------------------------------------------------------
-  const popupStyle = {
-    position: 'absolute',
-    top: '55px',
-    right: '0px',
-    backgroundColor: 'white',
-    borderRadius: '10px',
-    boxShadow: '0 4px 20px rgba(0,0,0,0.2)',
-    width: '320px',
-    maxHeight: '400px',
-    overflowY: 'auto',
-    zIndex: 1000,
-    color: '#333',
-  };
+  const unread = notifications.filter(n => !n.isRead);
 
-  const notificationItemStyle = (isRead) => ({
-    padding: '12px 16px',
-    borderBottom: '1px solid #f0f0f0',
-    backgroundColor: isRead ? 'white' : '#eef2ff',
-    cursor: 'pointer',
-    transition: 'background-color 0.2s',
-  });
-
-  // ------------------------------------------------------------------
-  // Render
-  // ------------------------------------------------------------------
   return (
     <div ref={popupRef} style={{ position: 'relative', display: 'flex', alignItems: 'center' }}>
-      <div
-        onClick={handleBellClick}
-        style={{ cursor: 'pointer', display: 'flex', alignItems: 'center' }}
-      >
+      <div onClick={() => setOpen(prev => !prev)} style={{ cursor: 'pointer', display: 'flex', alignItems: 'center' }}>
         <img src={NotificationIcon} alt="Notifications" style={{ height: '42px' }} />
-
-        {unreadCount > 0 && (
-          <div
-            style={{
-              position: 'absolute',
-              top: '-4px',
-              right: '-4px',
-              backgroundColor: 'red',
-              color: 'white',
-              borderRadius: '50%',
-              width: '18px',
-              height: '18px',
-              fontSize: '11px',
-              fontWeight: 'bold',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            {unreadCount > 99 ? '99+' : unreadCount}
+        {unread.length > 0 && (
+          <div style={{
+            position: 'absolute',
+            top: '-4px',
+            right: '-4px',
+            backgroundColor: 'red',
+            color: 'white',
+            borderRadius: '50%',
+            width: '18px',
+            height: '18px',
+            fontSize: '11px',
+            fontWeight: 'bold',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+            {unread.length > 99 ? '99+' : unread.length}
           </div>
         )}
       </div>
 
-      {showPopup && (
-        <div style={popupStyle}>
-          <div
-            style={{
-              padding: '14px 16px',
-              fontWeight: '700',
-              fontSize: '16px',
-              borderBottom: '1px solid #e0e0e0',
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-            }}
-          >
-            <span>Notifications</span>
-            {unreadCount > 0 && (
-              <span
-                style={{ fontSize: '12px', color: '#274B93', cursor: 'pointer' }}
-                onClick={markAllAsRead}
-              >
-                Mark all as read
-              </span>
-            )}
+      {open && (
+        <div style={{
+          position: 'absolute',
+          top: '55px',
+          right: '0px',
+          backgroundColor: 'white',
+          borderRadius: '10px',
+          boxShadow: '0 4px 20px rgba(0,0,0,0.2)',
+          width: '320px',
+          maxHeight: '400px',
+          overflowY: 'auto',
+          zIndex: 1000,
+          color: '#333',
+        }}>
+          <div style={{ padding: '14px 16px', fontWeight: '700', fontSize: '16px', borderBottom: '1px solid #e0e0e0' }}>
+            Notifications
           </div>
 
-          {notifications.length === 0 ? (
+          {unread.length === 0 ? (
             <div style={{ padding: '20px', textAlign: 'center', color: '#888', fontSize: '14px' }}>
-              No new applications yet
+              No new notifications
             </div>
           ) : (
-            notifications.map((n) => (
+            unread.map(n => (
               <div
-                key={n.id}
-                style={notificationItemStyle(n.isRead)}
-                onClick={handleNotificationClick}
+                key={n._id}
+                onClick={() => handleNotificationClick(n)}
+                style={{
+                  padding: '12px 16px',
+                  borderBottom: '1px solid #f0f0f0',
+                  backgroundColor: '#eef2ff',
+                  cursor: 'pointer',
+                  transition: 'background-color 0.2s',
+                }}
               >
-                <div style={{ fontWeight: '600', fontSize: '14px', marginBottom: '4px' }}>
-                  New application — {n.shiftTitle}
-                </div>
-                <div style={{ fontSize: '13px', color: '#555' }}>👤 {n.guardName}</div>
-                <div style={{ fontSize: '13px', color: '#555' }}>
-                  📅{' '}
-                  {new Date(n.shiftDate).toLocaleDateString('en-AU', {
-                    weekday: 'short',
-                    day: 'numeric',
-                    month: 'short',
-                    year: 'numeric',
+                <div style={{ fontWeight: '600', fontSize: '14px', marginBottom: '4px' }}>{n.title}</div>
+                <div style={{ fontSize: '13px', color: '#555' }}>{n.message}</div>
+                <div style={{ fontSize: '12px', color: '#aaa', marginTop: '4px' }}>
+                  {new Date(n.createdAt).toLocaleDateString('en-AU', {
+                    weekday: 'short', day: 'numeric', month: 'short', year: 'numeric',
                   })}
-                </div>
-                <div style={{ fontSize: '13px', color: '#555' }}>
-                  🕐 {n.shiftStartTime} – {n.shiftEndTime}
                 </div>
               </div>
             ))

--- a/app-frontend/employer-panel/src/pages/NotificationsPopup.js
+++ b/app-frontend/employer-panel/src/pages/NotificationsPopup.js
@@ -91,6 +91,7 @@ export default function NotificationsPopup() {
     return () => clearInterval(interval);
   }, []);
 
+  // Close popup when clicking outside
   useEffect(() => {
     const handleClickOutside = (e) => {
       if (popupRef.current && !popupRef.current.contains(e.target)) {

--- a/app-frontend/employer-panel/src/pages/NotificationsPopup.js
+++ b/app-frontend/employer-panel/src/pages/NotificationsPopup.js
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import NotificationIcon from '../components/NotificationIcon.svg';
 import http from '../lib/http';
 
-const POLL_INTERVAL = 30_000;
+const POLL_INTERVAL_MS = 30_000;
 
 export default function NotificationsPopup() {
   const navigate = useNavigate();
@@ -87,7 +87,7 @@ export default function NotificationsPopup() {
       pollShifts();
     };
     init();
-    const interval = setInterval(pollShifts, POLL_INTERVAL);
+    const interval = setInterval(pollShifts, POLL_INTERVAL_MS);
     return () => clearInterval(interval);
   }, []);
 


### PR DESCRIPTION
Fixed where refreshing would still show notification.

Updated code to connect to notifications in the database.  Previously notifications wree generated client-side by diffing applications on each poll and stored locally.  This causes read state to be lost on page refresh

- Notifications are written to the db when a new application is detected
- On mount, existing notifications are loaded and used to seed the application tracking ref, to prevent duplicates
- Opening notification dropdown doesn't mark as read.  Read state is updated when it is clicked
- Dropdown only shows unread notifications

<img width="2560" height="1392" alt="Fix1-AlertBubble" src="https://github.com/user-attachments/assets/8e2059ff-9b46-41a9-9c1b-e131ba1f2be0" />
<img width="2560" height="1392" alt="Fix2-LinksToManageShifts" src="https://github.com/user-attachments/assets/ec264285-1445-48fb-b652-d37d0ef23e20" />
