### PR TITLE
Fix Shift lifecycle issue

### DIFF
--- a/app-backend/src/controllers/shift.controller.js
+++ b/app-backend/src/controllers/shift.controller.js
@@ -347,7 +347,7 @@ export const updateShift = async (req, res) => {
     }
 
     const updates = {};
-    const { title, date, startTime, endTime, payRate, urgency, field, location, description, requirements } = req.body;
+    const { title, date, startTime, endTime, payRate, urgency, field, location, description, requirements, status } = req.body;
 
     if (title !== undefined) {
       if (typeof title !== 'string' || title.trim().length < 3) {
@@ -433,11 +433,11 @@ export const updateShift = async (req, res) => {
       updates.location = loc;
     }
     if (status !== undefined) {
-      const allowedStatuses = ['draft', 'open'];
+      const allowedStatuses = ['draft', 'open', 'applied', 'assigned', 'completed'];
 
       if (!allowedStatuses.includes(status)) {
         return res.status(400).json({
-          message: 'Invalid status. Allowed: draft, open'
+          message: 'Invalid status. Allowed: draft, open, applied, assigned, completed'
         });
       }
 
@@ -451,7 +451,10 @@ export const updateShift = async (req, res) => {
         // allowed transitions
         const allowedTransitions = {
           draft: ['open'],
-          open: ['draft'],
+          open: ['draft', 'applied', 'assigned'],
+          applied: ['open', 'assigned'],
+          assigned: ['completed', 'open'],
+          completed: [],
         };
 
         if (!allowedTransitions[current]?.includes(status)) {

--- a/app-frontend/employer-panel/src/pages/ManageShift.js
+++ b/app-frontend/employer-panel/src/pages/ManageShift.js
@@ -10,6 +10,14 @@ const statusDisplayMap = {
   open: 'Open',
 };
 
+// Map display status back to backend status
+const displayToBackendStatusMap = {
+  'Completed': 'completed',
+  'In Progress': 'assigned',
+  'Pending': 'applied',
+  'Open': 'open',
+};
+
 const Filter = Object.freeze({
   All: 'All',
   Completed: 'Completed',
@@ -63,7 +71,6 @@ const ManageShift = () => {
   const [saving, setSaving] = useState(false);
   const [feedback, setFeedback] = useState('');
   const [formErrors, setFormErrors] = useState({});
-  const [optimisticSnapshot, setOptimisticSnapshot] = useState(null);
   const [activeTab, setActiveTab] = useState(TABS.DETAILS);
   const [applicantAction, setApplicantAction] = useState({});
   const itemsPerPage = 9;
@@ -316,12 +323,8 @@ const ManageShift = () => {
         ...(detailForm.field?.trim() ? { field: detailForm.field.trim() } : {}),
         urgency: detailForm.urgency,
         ...(hasLocation ? { location: cleanedLocation } : {}),
+        status: displayToBackendStatusMap[detailForm.status] || detailForm.status,
       };
-      setOptimisticSnapshot({ shifts, selectedShift });
-      const optimistic = { ...selectedShift, ...payload, status: detailForm.status };
-      setShifts((prev) =>
-        prev.map((s) => (s.id === selectedShift.id ? { ...s, ...optimistic } : s))
-      );
       const { data } = await http.patch(`/shifts/${selectedShift.id}`, payload);
       const updated = normalizeShift(data.shift || { ...selectedShift, ...payload });
       const updatedWithUiStatus = { ...updated, status: detailForm.status };
@@ -348,10 +351,6 @@ const ManageShift = () => {
     } catch (err) {
       const message = err?.response?.data?.message || 'Failed to update shift';
       setFeedback(message);
-      if (optimisticSnapshot) {
-        setShifts(optimisticSnapshot.shifts);
-        setSelectedShift(optimisticSnapshot.selectedShift);
-      }
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
Support shift status editing with proper state transitions and mapping

- Expand updateShift endpoint to handle all valid statuses
- Define complete state transition rules (open→applied/assigned, etc)
- Add displayToBackendStatusMap for UI↔backend sync
- Remove optimistic update that could cause state reversion
<img width="1371" height="600" alt="iShot_2026-04-17_16 03 43" src="https://github.com/user-attachments/assets/2ecec1ce-0b48-427b-b1c9-ea60955b0ddf" />
<img width="1342" height="662" alt="iShot_2026-04-17_16 03 56" src="https://github.com/user-attachments/assets/c9ff7b6e-17b2-4b13-8438-0303613d6a65" />
<img width="1344" height="707" alt="iShot_2026-04-17_16 04 18" src="https://github.com/user-attachments/assets/ff199dd7-bc42-4f17-b16b-195a83a5c164" />
<img width="1374" height="651" alt="iShot_2026-04-17_16 04 25" src="https://github.com/user-attachments/assets/916e8be5-df38-475c-a12b-a422e9d0c991" />
<img width="1344" height="754" alt="iShot_2026-04-17_16 04 32" src="https://github.com/user-attachments/assets/0a98050a-7b0d-401d-9c32-f38ce47301a3" />
