### PR TITLE
fix: create shift button, site API integration and payload fixes

### DIFF
--- a/app-frontend/employer-panel/src/pages/CreateShift.css
+++ b/app-frontend/employer-panel/src/pages/CreateShift.css
@@ -103,6 +103,11 @@
   outline: none;
 }
 
+.cs-field select option {
+  color: #000000;
+  background: #ffffff;
+}
+
 .cs-field input:focus,
 .cs-field select:focus,
 .cs-field textarea:focus {

--- a/app-frontend/employer-panel/src/pages/EmployerDashboard.js
+++ b/app-frontend/employer-panel/src/pages/EmployerDashboard.js
@@ -1,7 +1,6 @@
 import React, { useMemo, useRef, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom"; 
 import "./EmployerDashboard.css";
-import CreateShift from "./createShift";
 
 /* --- icons --- */
 const IconCalendar = (props) => (
@@ -84,7 +83,6 @@ export default function EmployerDashboard() {
   const [shifts, setShifts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [showCreateModal, setShowCreateModal] = useState(false); // <-- added
 
   // States for Incident Management
   const [selectedIncident, setSelectedIncident] = useState(null);
@@ -250,7 +248,7 @@ useEffect(() => {
           <div className="ss-controls-right">
             <button
               className="ss-primary ss-primary--wide"
-                onClick={() => setShowCreateModal(true)}
+              onClick={() => navigate("/create-shift")}
             >
               <IconPlus className="ss-plus" /> Create Shift
             </button>
@@ -277,13 +275,7 @@ useEffect(() => {
           <div className="ss-panel">
             <div ref={overviewScroller} className={`ss-shifts ${view === "grid" ? "ss-shifts--grid" : "ss-shifts--list"}`}>
 
-              {/* Create Shift Card (only in grid view) */}
-              {view === "grid" && (
-                <div className="ss-card ss-card--create" onClick={() => navigate("/create-shift")}> 
-                  <div className="ss-card__createicon"><IconPlus /></div>
-                  <div className="ss-card__createtext">Create Shift</div>
-                </div>
-              )}
+
               {loading && <div>Loading shifts...</div>}
               {error && <div style={{color:'red'}}>{error}</div>}
               {!loading && !error && shifts.length === 0 && <div>No shifts found.</div>}
@@ -502,12 +494,7 @@ useEffect(() => {
         </div>
       )}
 
-      {showCreateModal && (
-        <CreateShift
-          isModal
-          onClose={() => setShowCreateModal(false)}
-        />
-      )}
+
     </div>
   );
 }

--- a/app-frontend/employer-panel/src/pages/createShift.js
+++ b/app-frontend/employer-panel/src/pages/createShift.js
@@ -71,29 +71,6 @@ const shiftSchema = yup.object({
   newSiteAddress: yup.string(),
 });
 
-const seededSites = [
-  {
-    id: 'marvel-stadium',
-    name: 'Marvel Stadium',
-    address: '740 Bourke St, Docklands VIC',
-    lat: -37.8167,
-    lng: 144.9475,
-  },
-  {
-    id: 'chadstone',
-    name: 'Chadstone Shopping Centre',
-    address: '1341 Dandenong Rd, Chadstone VIC',
-    lat: -37.8864,
-    lng: 145.0828,
-  },
-  {
-    id: 'aig-hq',
-    name: 'AIG Solutions HQ',
-    address: '373 Collins St, Melbourne VIC',
-    lat: -37.8172,
-    lng: 144.9632,
-  },
-];
 
 const guardOptions = [
   { id: 'g-smith', name: 'John Smith', skills: 'Events, RSA' },
@@ -141,6 +118,12 @@ const existingShifts = [
 
 const mapDefault = { lat: -37.8136, lng: 144.9631 }; // Melbourne CBD
 
+const parseAddress = (address) => {
+  const match = address.match(/^(.+),\s*(.+?)\s+([A-Z]{2,3})\s+(\d{4})$/);
+  if (match) return { street: match[1], suburb: match[2], state: match[3], postcode: match[4] };
+  return { street: address, suburb: '', state: '', postcode: '' };
+};
+
 const slugify = (text) =>
   text
     .toLowerCase()
@@ -168,7 +151,8 @@ const loadGooglePlaces = (onReady, onError) => {
 
 const CreateShift = ({ isModal = false, onClose }) => {
   const navigate = useNavigate();
-  const [sites, setSites] = useState(seededSites);
+  const [sites, setSites] = useState([]);
+  const [pendingSiteId, setPendingSiteId] = useState(null);
   const [showNewSite, setShowNewSite] = useState(false);
   const [previewData, setPreviewData] = useState(null);
   const [blockingIssues, setBlockingIssues] = useState([]);
@@ -213,8 +197,27 @@ const CreateShift = ({ isModal = false, onClose }) => {
 
   const watchSiteId = watch('siteId');
   const watchGuards = watch('guards');
+  const isExistingSite = Boolean(watchSiteId && watchSiteId !== '__new');
   const newSiteNameReg = register('newSiteName');
   const newSiteAddressReg = register('newSiteAddress');
+
+  useEffect(() => {
+    http.get('/branch/site')
+      .then((res) => {
+        const fetched = (res.data.sites || []).map((s) => ({
+          id: s._id,
+          name: s.name,
+          address: [s.location?.line1, s.location?.city, s.location?.state, s.location?.postcode]
+            .filter(Boolean).join(', '),
+          street: s.location?.line1,
+          suburb: s.location?.city,
+          state: s.location?.state,
+          postcode: s.location?.postcode,
+        }));
+        setSites(fetched);
+      })
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     loadGooglePlaces(
@@ -310,6 +313,14 @@ const CreateShift = ({ isModal = false, onClose }) => {
     }
   }, [watchSiteId, sites, setValue]);
 
+  useEffect(() => {
+    if (!pendingSiteId) return;
+    if (sites.find((s) => s.id === pendingSiteId)) {
+      setValue('siteId', pendingSiteId, { shouldValidate: true });
+      setPendingSiteId(null);
+    }
+  }, [sites, pendingSiteId, setValue]);
+
   const overlaps = (startA, endA, startB, endB) => {
     if (!startA || !endA || !startB || !endB) return false;
     return startA < endB && endA > startB;
@@ -370,18 +381,26 @@ const CreateShift = ({ isModal = false, onClose }) => {
       setBlockingIssues([`Add new site: ${missing.join(' and ')} required`]);
       return;
     }
-    const newId = slugify(trimmedName);
-    const nextSite = {
-      id: newId,
-      name: trimmedName,
-      address: trimmedAddress,
-      lat: locationPin.lat,
-      lng: locationPin.lng,
-    };
-    setSites((prev) => [...prev, nextSite]);
-    setValue('siteId', newId, { shouldValidate: true });
-    setShowNewSite(false);
-    setBlockingIssues([]);
+    try {
+      const res = await http.post('/branch/site', {
+        name: trimmedName,
+        code: slugify(trimmedName),
+        location: { line1: trimmedAddress },
+      });
+      const newSite = res.data;
+      const nextSite = {
+        id: newSite._id,
+        name: newSite.name,
+        address: trimmedAddress,
+      };
+      setSites((prev) => [...prev, nextSite]);
+      setPendingSiteId(newSite._id);
+      setShowNewSite(false);
+      setBlockingIssues([]);
+    } catch (err) {
+      const message = err?.response?.data?.message || 'Failed to create site';
+      setBlockingIssues([message]);
+    }
   };
 
   const onPreview = (values) => {
@@ -411,14 +430,18 @@ const CreateShift = ({ isModal = false, onClose }) => {
       endTime: values.endTime,
       breakMinutes: values.breakMinutes,
       payRate: values.payRate,
-      shiftType: values.shiftType,
-      instructions: values.instructions,
+      shiftType: values.shiftType === 'day' ? 'Day' : 'Night',
+      description: values.instructions,
       guards: values.guards || [],
-      location: {
-        street: values.location,
-        lat: locationPin.lat,
-        lng: locationPin.lng,
-      },
+      location: (() => {
+        const parsed = parseAddress(selectedSite?.address || values.location);
+        return {
+          street: selectedSite?.street || parsed.street,
+          suburb: selectedSite?.suburb || parsed.suburb,
+          state: selectedSite?.state || parsed.state,
+          postcode: selectedSite?.postcode || parsed.postcode,
+        };
+      })(),
     };
 
     try {
@@ -542,21 +565,25 @@ const CreateShift = ({ isModal = false, onClose }) => {
                 render={({ field }) => (
                   <input
                     id="location"
-                    placeholder="Type to search and pin"
+                    placeholder={isExistingSite ? '' : 'Type to search and pin'}
+                    readOnly={isExistingSite}
                     {...field}
                     ref={(node) => {
                       locationInputRef.current = node;
                       field.ref(node);
                     }}
                     onChange={(e) => {
-                      field.onChange(e.target.value);
+                      if (!isExistingSite) field.onChange(e.target.value);
                     }}
+                    style={isExistingSite ? { cursor: 'default', opacity: 0.7 } : undefined}
                   />
                 )}
               />
               {renderFieldError('location')}
               <p className="cs-hint">
-                We pin this exact location on the map. Use autocomplete for accuracy.
+                {isExistingSite
+                  ? 'Location is set by the selected site.'
+                  : 'We pin this exact location on the map. Use autocomplete for accuracy.'}
               </p>
             </div>
 


### PR DESCRIPTION
This PR resolves the Create Shift button issues and integrates the frontend with backend Sites APIs.

Changes:
1. **Fix: Dashboard "Create Shift" button now navigates to `/create-shift`**
- removed inline CreateShift modal that was rendering inside the dashboard
- Button now routes to the full `/create-shift` page via `navigate("/create-shift")`
- removed duplicate "Create Shift" grid card that appeared in grid view
- removed unused CreateShift import and showCreateModal state

<img width="2411" height="1147" alt="image" src="https://github.com/user-attachments/assets/12ba6e23-00c1-46ce-b0ae-cd1c4be229f6" />


2. **Fix: Google Location - read-only for existing sites, editable for new sites**
- location input is now `readOnly` when an existing site is selected
- location input is editable when adding a new site

<img width="672" height="304" alt="image" src="https://github.com/user-attachments/assets/37464b18-0eb7-4dd9-b44f-3c340a5bb96e" />

editable
<img width="619" height="441" alt="image" src="https://github.com/user-attachments/assets/b8cd1c43-1587-4891-b919-7f867d5049b4" />


3. **Fix: Site dropdown now loads from the real backend API**
- removed hardcoded `seededSites `array
- sites are fetched from `GET /api/v1/branch/site` on component mount
- adding a new site called `POST /api/v1/branch/site` and persists to the database
- newly created site is automatically selected in the dropdown after saving

4. **Fix: `description` field now correctly mapped**
- frontend was sending `instructions` but backend expects `description`
- fixed by mapping `description: values.instructions` in the payload

5. **Fix: `shiftType` casing now matches backend expectations**
- frontend form uses lowercase `'day' / 'night` internally
- payload now converts to `'Day / 'Night;` before sending to backend

6. **Fix: Location object now includes all required fields**
- backend requires `street`, `suburb`, `state` and `postcode`
- added `parseAddress()` helper to extract structured fields from formatted address strings
- payload now sends all four location fields correctly

7. **Site dropdown option text color**
- dropdown options were rendering with white text on white background
- fixed with explicit `color: #000000` in CSS

<img width="522" height="289" alt="image" src="https://github.com/user-attachments/assets/1f548b46-420d-45d4-b53c-adc9f7bf3647" />


