### PR TITLE
Add Terms of Service screen and replace Coming Soon alert

### DIFF
--- a/guard_app/src/navigation/AppNavigator.tsx
+++ b/guard_app/src/navigation/AppNavigator.tsx
@@ -104,14 +104,14 @@ export default function AppNavigator() {
         component={ShiftDetailsScreen}
         options={{ headerShown: true, title: t('nav.shiftDetails') }}
       />
-<<<<<<< HEAD
-=======
+       HEAD
+
       <Stack.Screen
         name="Terms"
         component={TermsScreen}
         options={{ headerShown: true, title: 'Terms of Service' }}
       />
->>>>>>> dc993c34 (Add Terms of Service screen and replace Coming Soon alert)
+       dc993c34 (Add Terms of Service screen and replace Coming Soon alert)
     </Stack.Navigator>
   );
 }

--- a/guard_app/src/navigation/AppNavigator.tsx
+++ b/guard_app/src/navigation/AppNavigator.tsx
@@ -13,6 +13,10 @@ import SettingsScreen from '../screen/SettingsScreen';
 import ShiftDetailsScreen from '../screen/ShiftDetailsScreen';
 import SignupScreen from '../screen/signupscreen';
 import SplashScreen from '../screen/SplashScreen';
+<<<<<<< HEAD
+=======
+import TermsScreen from '../screen/TermsScreen';
+>>>>>>> dc993c34 (Add Terms of Service screen and replace Coming Soon alert)
 import { useAppTheme } from '../theme';
 
 export type RootStackParamList = {
@@ -100,6 +104,14 @@ export default function AppNavigator() {
         component={ShiftDetailsScreen}
         options={{ headerShown: true, title: t('nav.shiftDetails') }}
       />
+<<<<<<< HEAD
+=======
+      <Stack.Screen
+        name="Terms"
+        component={TermsScreen}
+        options={{ headerShown: true, title: 'Terms of Service' }}
+      />
+>>>>>>> dc993c34 (Add Terms of Service screen and replace Coming Soon alert)
     </Stack.Navigator>
   );
 }

--- a/guard_app/src/navigation/AppNavigator.tsx
+++ b/guard_app/src/navigation/AppNavigator.tsx
@@ -13,10 +13,7 @@ import SettingsScreen from '../screen/SettingsScreen';
 import ShiftDetailsScreen from '../screen/ShiftDetailsScreen';
 import SignupScreen from '../screen/signupscreen';
 import SplashScreen from '../screen/SplashScreen';
-<<<<<<< HEAD
-=======
 import TermsScreen from '../screen/TermsScreen';
->>>>>>> dc993c34 (Add Terms of Service screen and replace Coming Soon alert)
 import { useAppTheme } from '../theme';
 
 export type RootStackParamList = {
@@ -41,6 +38,7 @@ export type RootStackParamList = {
   Notifications: undefined;
   Certificates: undefined;
   ShiftDetails: { shift: any };
+  Terms: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -104,14 +102,11 @@ export default function AppNavigator() {
         component={ShiftDetailsScreen}
         options={{ headerShown: true, title: t('nav.shiftDetails') }}
       />
-       HEAD
-
       <Stack.Screen
         name="Terms"
         component={TermsScreen}
         options={{ headerShown: true, title: 'Terms of Service' }}
       />
-       dc993c34 (Add Terms of Service screen and replace Coming Soon alert)
     </Stack.Navigator>
   );
 }

--- a/guard_app/src/navigation/AppNavigator.tsx
+++ b/guard_app/src/navigation/AppNavigator.tsx
@@ -110,4 +110,3 @@ export default function AppNavigator() {
     </Stack.Navigator>
   );
 }
-

--- a/guard_app/src/navigation/AppNavigator.tsx
+++ b/guard_app/src/navigation/AppNavigator.tsx
@@ -110,3 +110,4 @@ export default function AppNavigator() {
     </Stack.Navigator>
   );
 }
+

--- a/guard_app/src/screen/SettingsScreen.tsx
+++ b/guard_app/src/screen/SettingsScreen.tsx
@@ -253,6 +253,7 @@ export default function SettingsScreen() {
           <Row
             icon={<Ionicons name="shield-checkmark-outline" size={18} color={colors.primary} />}
             label={t('settings.tos')}
+            onPress={() => navigation2.navigate('Terms')}
             colors={colors}
           />
         </View>

--- a/guard_app/src/screen/TermsScreen.tsx
+++ b/guard_app/src/screen/TermsScreen.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
+
+const TermsScreen = () => {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>Terms of Service</Text>
+
+      <Text style={styles.sectionTitle}>Usage Rules</Text>
+      <Text style={styles.text}>
+        - Use the app responsibly{'\n'}- Do not misuse the platform{'\n'}- Follow all guidelines
+        provided
+      </Text>
+
+      <Text style={styles.sectionTitle}>User Responsibilities</Text>
+      <Text style={styles.text}>
+        - Keep your account secure{'\n'}- Provide accurate information{'\n'}- Respect other users
+      </Text>
+
+      <Text style={styles.sectionTitle}>Account Restrictions</Text>
+      <Text style={styles.text}>
+        - Accounts may be suspended for violations{'\n'}- Multiple fake accounts are not allowed
+        {'\n'}- Any suspicious activity may lead to termination
+      </Text>
+    </ScrollView>
+  );
+};
+
+export default TermsScreen;
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 20,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    marginBottom: 15,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginTop: 15,
+  },
+  text: {
+    fontSize: 14,
+    marginTop: 5,
+    lineHeight: 20,
+  },
+});


### PR DESCRIPTION
Implemented Terms of Service screen and replaced Coming Soon popup with navigation.

Includes:
- New Terms screen
- Navigation integration

Screenshots will be added below.

<img width="430" height="1022" alt="Evidence1" src="https://github.com/user-attachments/assets/a16e1b8f-9741-40b1-9ea5-f3d4344277f3" />
<img width="494" height="1024" alt="Evidence2" src="https://github.com/user-attachments/assets/39191378-06ac-4e16-848c-1df73712b872" />

