### PR TITLE
Fix dashboard to display shifts correctly for logged-in employer

### DIFF
--- a/app-frontend/employer-panel/src/pages/EmployerDashboard.js
+++ b/app-frontend/employer-panel/src/pages/EmployerDashboard.js
@@ -255,7 +255,7 @@ useEffect(() => {
           <div className="ss-controls-right">
             <button
               className="ss-primary ss-primary--wide"
-              onClick={() => setShowCreateModal(true)}
+              onClick={() => navigate("/create-shift")}
             >
               <IconPlus className="ss-plus" /> Create Shift
             </button>


### PR DESCRIPTION
This PR fixes the issue in the Employer Dashboard caused by the create modal logic

Issue:
The dashboard was previously using a modal-based approach for creating shifts. However, the modal state (`setShowCreat
eModal`) was not properly defined or handled after recent updates, which caused runtime errors and broke the dashboard functionality.

Fix:
* Removed the create modal trigger logic from the dashboard
* Replaced it with navigation to the `/create-shift` page using `navigate()`
* Ensured the Create Shift button works consistently without causing errors

Result:
* The dashboard no longer crashes due to undefined modal state
* The Create Shift button now correctly redirects to the Create Shift page
* Dashboard functionality remains stable and unaffected by the previous modal issue

This change aligns the dashboard with the current navigation-based flow and resolves the issue that was breaking the logic.
<img width="1423" height="849" alt="Screenshot 2026-04-16 at 11 10 45 PM" src="https://github.com/user-attachments/assets/2e49c61b-ed57-4fc6-befb-b447ef0e0ad9" />
