### PR TITLE
Fix check-in/check-out button visibility and state sync

### DIFF
--- a/guard_app/src/screen/ShiftDetailsScreen.tsx
+++ b/guard_app/src/screen/ShiftDetailsScreen.tsx
@@ -138,8 +138,9 @@ export default function ShiftDetailsScreen() {
 
         const records = await getUserAttendance(userId);
         const match = records.find(
-          (r) => String(r.shiftId === 'object' ? (r.shiftId as any)?._id : r.shiftId) === String(shift._id) ||
-                 String(r.shiftId) === String(shift._id),
+          (r) =>
+            String(r.shiftId === 'object' ? (r.shiftId as any)?._id : r.shiftId) ===
+              String(shift._id) || String(r.shiftId) === String(shift._id),
         );
         if (match?.checkInTime) {
           const synced = normalizeAttendance(match);

--- a/guard_app/src/screen/ShiftDetailsScreen.tsx
+++ b/guard_app/src/screen/ShiftDetailsScreen.tsx
@@ -5,10 +5,11 @@ import { AxiosError } from 'axios';
 import React, { useEffect, useState } from 'react';
 import { Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-import { checkIn, checkOut } from '../api/attendance';
+import { checkIn, checkOut, getUserAttendance } from '../api/attendance';
 import ErrorMessageBox from '../components/ErrorMessageBox';
 import LocationVerificationModal from '../components/LocationVerificationModal';
 import { getAttendanceForShift, setAttendanceForShift } from '../lib/attendancestore';
+import { LocalStorage } from '../lib/localStorage';
 import { useAppTheme } from '../theme';
 import { formatDate } from '../utils/date';
 
@@ -123,7 +124,31 @@ export default function ShiftDetailsScreen() {
   useEffect(() => {
     (async () => {
       const storedAttendance = await getAttendanceForShift(shift._id);
-      setAttendance(storedAttendance ? normalizeAttendance(storedAttendance) : null);
+      if (storedAttendance?.checkInTime) {
+        setAttendance(normalizeAttendance(storedAttendance));
+        return;
+      }
+
+      try {
+        const token = await LocalStorage.getToken();
+        if (!token) return;
+        const payload = JSON.parse(atob(token.split('.')[1]));
+        const userId = payload.id ?? payload._id ?? payload.sub;
+        if (!userId) return;
+
+        const records = await getUserAttendance(userId);
+        const match = records.find(
+          (r) => String(r.shiftId === 'object' ? (r.shiftId as any)?._id : r.shiftId) === String(shift._id) ||
+                 String(r.shiftId) === String(shift._id),
+        );
+        if (match?.checkInTime) {
+          const synced = normalizeAttendance(match);
+          setAttendance(synced);
+          setAttendanceForShift(shift._id, synced).catch(() => {});
+        }
+      } catch {
+        // server fetch failed, stay with null
+      }
     })();
   }, [shift._id]);
 
@@ -219,12 +244,12 @@ export default function ShiftDetailsScreen() {
         const res = await checkIn(shift._id, loc);
 
         const next: AttendanceState = normalizeAttendance({
-          checkInTime: res.attendance?.checkInTime,
+          checkInTime: res.attendance?.checkInTime ?? new Date().toISOString(),
           checkOutTime: undefined,
         });
 
-        await setAttendanceForShift(shift._id, next);
         setAttendance(next);
+        setAttendanceForShift(shift._id, next).catch(() => {});
 
         Alert.alert('Success', 'Checked in successfully ✅');
       } else {
@@ -242,12 +267,12 @@ export default function ShiftDetailsScreen() {
         const res = await checkOut(shift._id, loc);
 
         const next: AttendanceState = normalizeAttendance({
-          checkInTime: res.attendance?.checkInTime,
-          checkOutTime: res.attendance?.checkOutTime,
+          checkInTime: res.attendance?.checkInTime ?? attendance?.checkInTime,
+          checkOutTime: res.attendance?.checkOutTime ?? new Date().toISOString(),
         });
 
-        await setAttendanceForShift(shift._id, next);
         setAttendance(next);
+        setAttendanceForShift(shift._id, next).catch(() => {});
 
         Alert.alert('Success', 'Checked out successfully ✅');
       }
@@ -290,6 +315,13 @@ export default function ShiftDetailsScreen() {
         normalizedMsg.includes('within 100 metres')
       ) {
         showErrorBox('Location mismatch', msg);
+        return;
+      }
+
+      if (normalizedMsg.includes('already checked in')) {
+        const synced: AttendanceState = { checkInTime: new Date().toISOString() };
+        setAttendance(synced);
+        setAttendanceForShift(shift._id, synced).catch(() => {});
         return;
       }
 


### PR DESCRIPTION
## Summary
- Call `setAttendance` before AsyncStorage write so the Check Out button appears immediately after check-in
- Add fallback timestamp when backend response omits `checkInTime`/`checkOutTime`
- Handle "Already checked in" response by silently syncing local state and revealing the Check Out button

## Test plan
- [ ] Check in on an assigned shift — Check Out button appears immediately
- [ ] Restart app after check-in — Check Out button still appears on re-open
- [ ] Attempt duplicate check-in — Check Out button appears without showing an error

<img width="691" height="1627" alt="Screenshot 2026-04-26 at 10 58 14 pm" src="https://github.com/user-attachments/assets/110f0c1a-6498-4ec6-b5ee-1d28d7095d1a" />
