### PR TITLE
fix(messages): allow guard-to-guard chat

### DIFF
--- a/app-backend/src/controllers/message.controller.js
+++ b/app-backend/src/controllers/message.controller.js
@@ -37,16 +37,18 @@ const sendMessage = async (req, res, next) => {
       throw error;
     }
 
-    //Ensure communication is only between guards and employers
+    // Allow guard-to-guard and guard/employer messaging, but keep
+    // employer-to-employer and admin messaging blocked.
     const senderRole = req.user.role;
     const receiverRole = receiver.role;
     
     const validCommunication = 
+      (senderRole === 'guard' && receiverRole === 'guard') ||
       (senderRole === 'guard' && receiverRole === 'employer') ||
       (senderRole === 'employer' && receiverRole === 'guard');
 
     if (!validCommunication) {
-      const error = new Error('Messages can only be sent between guards and employers');
+      const error = new Error('Messages can only be sent between guards, or between guards and employers');
       error.status = 403;
       throw error;
     }

--- a/app-backend/src/routes/message.routes.js
+++ b/app-backend/src/routes/message.routes.js
@@ -17,7 +17,7 @@ router.use(auth);
  * @swagger
  * tags:
  *   name: Messages
- *   description: Messaging endpoints between guards and employers
+ *   description: Messaging endpoints between guards, and between guards and employers
  */
 
 /**

--- a/app-backend/tests/message.controller.test.js
+++ b/app-backend/tests/message.controller.test.js
@@ -1,0 +1,145 @@
+jest.mock('../src/models/User.js', () => ({
+  __esModule: true,
+  default: {
+    findById: jest.fn(),
+  },
+}));
+
+jest.mock('../src/models/Message.js', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(function Message(data) {
+    Object.assign(this, {
+      _id: 'message-123',
+      timestamp: new Date('2026-04-27T00:00:00.000Z'),
+      isRead: false,
+      ...data,
+      save: jest.fn().mockResolvedValue(undefined),
+      populate: jest.fn().mockResolvedValue(undefined),
+    });
+  }),
+}));
+
+jest.mock('express-validator', () => ({
+  validationResult: jest.fn(),
+}));
+
+import User from '../src/models/User.js';
+import Message from '../src/models/Message.js';
+import { validationResult } from 'express-validator';
+import { sendMessage } from '../src/controllers/message.controller.js';
+
+const createReq = ({ senderId = 'guard-1', senderRole = 'guard', receiverId = 'guard-2' } = {}) => ({
+  body: {
+    receiverId,
+    content: ' Hello from SecureShift ',
+  },
+  user: {
+    id: senderId,
+    role: senderRole,
+  },
+  audit: {
+    log: jest.fn().mockResolvedValue(undefined),
+  },
+});
+
+const createRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  validationResult.mockReturnValue({
+    isEmpty: () => true,
+    array: () => [],
+  });
+});
+
+test('sendMessage allows guard-to-guard messaging', async () => {
+  User.findById.mockResolvedValue({
+    _id: 'guard-2',
+    role: 'guard',
+    email: 'guard2@example.com',
+    name: 'Guard Two',
+  });
+
+  const req = createReq();
+  const res = createRes();
+  const next = jest.fn();
+
+  await sendMessage(req, res, next);
+
+  expect(Message).toHaveBeenCalledWith({
+    sender: 'guard-1',
+    receiver: 'guard-2',
+    content: 'Hello from SecureShift',
+  });
+  expect(Message.mock.instances[0].save).toHaveBeenCalled();
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith(
+    expect.objectContaining({
+      success: true,
+      data: expect.objectContaining({
+        messageId: 'message-123',
+        content: 'Hello from SecureShift',
+      }),
+    })
+  );
+  expect(next).not.toHaveBeenCalled();
+});
+
+test('sendMessage still blocks employer-to-employer messaging', async () => {
+  User.findById.mockResolvedValue({
+    _id: 'employer-2',
+    role: 'employer',
+    email: 'employer2@example.com',
+    name: 'Employer Two',
+  });
+
+  const req = createReq({
+    senderId: 'employer-1',
+    senderRole: 'employer',
+    receiverId: 'employer-2',
+  });
+  const res = createRes();
+  const next = jest.fn();
+
+  await sendMessage(req, res, next);
+
+  expect(Message).not.toHaveBeenCalled();
+  expect(next).toHaveBeenCalledWith(
+    expect.objectContaining({
+      status: 403,
+      message: 'Messages can only be sent between guards, or between guards and employers',
+    })
+  );
+});
+
+test('sendMessage still blocks admin messaging', async () => {
+  User.findById.mockResolvedValue({
+    _id: 'guard-2',
+    role: 'guard',
+    email: 'guard2@example.com',
+    name: 'Guard Two',
+  });
+
+  const req = createReq({
+    senderId: 'admin-1',
+    senderRole: 'admin',
+    receiverId: 'guard-2',
+  });
+  const res = createRes();
+  const next = jest.fn();
+
+  await sendMessage(req, res, next);
+
+  expect(Message).not.toHaveBeenCalled();
+  expect(next).toHaveBeenCalledWith(
+    expect.objectContaining({
+      status: 403,
+      message: 'Messages can only be sent between guards, or between guards and employers',
+    })
+  );
+});


### PR DESCRIPTION
## Summary

Fixed guard-to-guard messaging in the backend.

Previously, `sendMessage` only allowed guard-to-employer and employer-to-guard communication, which caused guard-to-guard chat to be rejected with a 403 error.

## Changes

- Updated message role validation to allow:
  - guard → guard
  - guard → employer
  - employer → guard
- Kept employer → employer and admin-involved messaging blocked
- Updated the Swagger messaging tag description to match the new allowed communication paths
- Added a focused regression test for message role validation

## Validation

Passed:

```bash
npm test -- --runInBand message.controller.test.js
```
<img width="677" height="661" alt="Screenshot 2026-04-27 144359" src="https://github.com/user-attachments/assets/b730a23b-c7f0-4186-9a31-d276536ee139" />

<img width="1536" height="509" alt="Screenshot 2026-04-27 144910" src="https://github.com/user-attachments/assets/02cdf4de-2eb9-4e1f-8fe8-b03c44538142" />
