### PR TITLE
fix: Fixed the ESlint errors, removed the shift card in grid view, an…

### DIFF
--- a/app-frontend/employer-panel/src/pages/EmployerDashboard.js
+++ b/app-frontend/employer-panel/src/pages/EmployerDashboard.js
@@ -255,7 +255,7 @@ useEffect(() => {
           <div className="ss-controls-right">
             <button
               className="ss-primary ss-primary--wide"
-              onClick={() => setShowCreateModal(true)}
+              onClick={() => navigate("/create-shift")}
             >
               <IconPlus className="ss-plus" /> Create Shift
             </button>
@@ -291,16 +291,7 @@ useEffect(() => {
               className={`ss-shifts ${view === "grid" ? "ss-shifts--grid" : "ss-shifts--list"}`}
             >
   
-              {/* Create Shift Card (only in grid view) */}
-              {view === "grid" && (
-                <div
-                  className="ss-card ss-card--create"
-                  onClick={() => navigate("/create-shift")}
-                >
-                  <div className="ss-card__createicon"><IconPlus /></div>
-                  <div className="ss-card__createtext">Create Shift</div>
-                </div>
-              )}
+              
   
               {loading && <div>Loading shifts...</div>}
               {error && <div style={{ color: "red" }}>{error}</div>}


### PR DESCRIPTION
## Fix: EmployerDashboard Create Shift button & ESLint errors

### What was wrong
- `setShowCreateModal` was being called on the Create Shift button but the corresponding state was never declared, causing an ESLint error
- A duplicate Create Shift card existed inside the grid view, resulting in multiple Create Shift entry points which was confusing
- `showCreateModal` state was declared but never consumed anywhere in the JSX

### What was changed
- Removed the redundant Create Shift card from the grid view
- Removed the unused `showCreateModal` / `setShowCreateModal` state
- Updated the Create Shift button to use `navigate("/create-shift")` to navigate to the existing Create Shift page

### Why
Create Shift is a separate page, not a modal, so navigation is the correct behaviour. This also resolves all related ESLint warnings.
### Screenshots
<img width="1898" height="881" alt="Screenshot 2026-04-27 171422" src="https://github.com/user-attachments/assets/9b0f0248-3d15-4ecb-923d-30c4d7068122" />
<img width="1898" height="951" alt="Screenshot 2026-04-27 172807" src="https://github.com/user-attachments/assets/12afd089-fedd-4e0e-8ebe-521af48023c7" />