### PR TITLE
Add active SOS state screen with floating trigger button

### DIFF
--- a/guard_app/src/api/sos.ts
+++ b/guard_app/src/api/sos.ts
@@ -1,0 +1,242 @@
+// src/api/sos.ts
+import axios from 'axios';
+
+import http from '../lib/http';
+
+/**
+ * When the backend has the /sos/* routes implemented, set USE_MOCK_SOS to
+ * false (or remove the mock branches) so the real API is called instead.
+ */
+const USE_MOCK_SOS = true;
+
+export type LocationPayload = {
+  latitude: number;
+  longitude: number;
+  timestamp?: number;
+};
+
+export type SOSStatus =
+  | 'pending'
+  | 'notifying'
+  | 'notified'
+  | 'connected'
+  | 'cancelled'
+  | 'resolved';
+
+export type SOSEvent = {
+  status: SOSStatus;
+  message?: string;
+  at: string; // ISO timestamp
+};
+
+export type SOSAlert = {
+  _id: string;
+  guardId: string;
+  shiftId?: string | null;
+  triggeredAt: string;
+  status: SOSStatus;
+  statusMessage?: string;
+  location: LocationPayload;
+  history?: SOSEvent[];
+  note?: string;
+  emergencyContact?: {
+    name?: string;
+    phone?: string;
+  } | null;
+  cancelledAt?: string | null;
+  resolvedAt?: string | null;
+};
+
+type SOSResponse = {
+  message?: string;
+  sos: SOSAlert;
+};
+
+/* ------------------------------------------------------------------ */
+/* Mock implementation                                                 */
+/* ------------------------------------------------------------------ */
+
+let mockStore: SOSAlert | null = null;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function randomId() {
+  return 'mock-' + Math.random().toString(36).slice(2, 10);
+}
+
+function buildInitialAlert(loc: LocationPayload, note?: string): SOSAlert {
+  return {
+    _id: randomId(),
+    guardId: 'mock-guard',
+    shiftId: null,
+    triggeredAt: nowIso(),
+    status: 'pending',
+    statusMessage: 'Connecting to dispatch...',
+    location: loc,
+    note,
+    history: [{ status: 'pending', message: 'SOS triggered', at: nowIso() }],
+    // For emulator testing, use a non-emergency number so the dialer opens.
+    // In production this should be '000' (or whatever the emergency contact is).
+    emergencyContact: { name: 'Emergency Services', phone: '0412345678' },
+  };
+}
+
+/**
+ * Simulate the alert progressing through statuses based on how long it has
+ * been active. Each call to getSOSStatus moves it forward if appropriate.
+ */
+function advanceMockStatus(alertObj: SOSAlert): SOSAlert {
+  if (alertObj.status === 'cancelled' || alertObj.status === 'resolved') {
+    return alertObj;
+  }
+  const elapsed = Date.now() - new Date(alertObj.triggeredAt).getTime();
+  const next = { ...alertObj, history: [...(alertObj.history ?? [])] };
+  if (elapsed > 25_000 && alertObj.status !== 'connected') {
+    next.status = 'connected';
+    next.statusMessage = 'Connected to dispatch — help is on the way';
+    next.history.push({ status: 'connected', at: nowIso() });
+  } else if (elapsed > 15_000 && alertObj.status === 'notifying') {
+    next.status = 'notified';
+    next.statusMessage = 'Supervisor notified';
+    next.history.push({ status: 'notified', at: nowIso() });
+  } else if (elapsed > 5_000 && alertObj.status === 'pending') {
+    next.status = 'notifying';
+    next.statusMessage = 'Notifying supervisor...';
+    next.history.push({ status: 'notifying', at: nowIso() });
+  }
+  return next;
+}
+
+function delay<T>(value: T, ms = 250): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(value), ms));
+}
+
+/* ------------------------------------------------------------------ */
+/* Public API                                                          */
+/* ------------------------------------------------------------------ */
+
+// 🚨 Trigger SOS
+export async function triggerSOS(loc: LocationPayload, note?: string): Promise<SOSAlert> {
+  if (USE_MOCK_SOS) {
+    mockStore = buildInitialAlert(loc, note);
+    return delay(mockStore, 400);
+  }
+  try {
+    const { data } = await http.post<SOSResponse>('/sos/trigger', {
+      latitude: loc.latitude,
+      longitude: loc.longitude,
+      timestamp: loc.timestamp,
+      note,
+    });
+    return data.sos;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const message = error.response?.data?.message;
+      throw new Error(message || `Failed to trigger SOS (${error.response?.status ?? 'unknown'})`);
+    }
+    throw new Error('Failed to trigger SOS');
+  }
+}
+
+// 📍 Push a location update for an active SOS
+export async function updateSOSLocation(sosId: string, loc: LocationPayload): Promise<SOSAlert> {
+  if (USE_MOCK_SOS) {
+    if (!mockStore || mockStore._id !== sosId) {
+      throw new Error('No active mock SOS for that id');
+    }
+    mockStore = { ...mockStore, location: loc };
+    return delay(mockStore, 100);
+  }
+  try {
+    const { data } = await http.post<SOSResponse>(`/sos/${sosId}/location`, {
+      latitude: loc.latitude,
+      longitude: loc.longitude,
+      timestamp: loc.timestamp,
+    });
+    return data.sos;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const message = error.response?.data?.message;
+      throw new Error(
+        message || `Failed to update SOS location (${error.response?.status ?? 'unknown'})`,
+      );
+    }
+    throw new Error('Failed to update SOS location');
+  }
+}
+
+// 📝 Add or update a note on an active SOS
+export async function addSOSNote(sosId: string, note: string): Promise<SOSAlert> {
+  if (USE_MOCK_SOS) {
+    if (!mockStore || mockStore._id !== sosId) {
+      throw new Error('No active mock SOS for that id');
+    }
+    mockStore = { ...mockStore, note };
+    return delay(mockStore, 200);
+  }
+  try {
+    const { data } = await http.post<SOSResponse>(`/sos/${sosId}/note`, { note });
+    return data.sos;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const message = error.response?.data?.message;
+      throw new Error(message || `Failed to add SOS note (${error.response?.status ?? 'unknown'})`);
+    }
+    throw new Error('Failed to add SOS note');
+  }
+}
+
+// ❌ Cancel an active SOS (within grace period or with confirmation)
+export async function cancelSOS(sosId: string): Promise<SOSAlert> {
+  if (USE_MOCK_SOS) {
+    if (!mockStore || mockStore._id !== sosId) {
+      throw new Error('No active mock SOS for that id');
+    }
+    mockStore = {
+      ...mockStore,
+      status: 'cancelled',
+      statusMessage: 'SOS cancelled by guard',
+      cancelledAt: nowIso(),
+      history: [
+        ...(mockStore.history ?? []),
+        { status: 'cancelled', at: nowIso(), message: 'SOS cancelled by guard' },
+      ],
+    };
+    return delay(mockStore, 200);
+  }
+  try {
+    const { data } = await http.post<SOSResponse>(`/sos/${sosId}/cancel`, {});
+    return data.sos;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const message = error.response?.data?.message;
+      throw new Error(message || `Failed to cancel SOS (${error.response?.status ?? 'unknown'})`);
+    }
+    throw new Error('Failed to cancel SOS');
+  }
+}
+
+// 🔄 Get the latest status for an active SOS (used for polling)
+export async function getSOSStatus(sosId: string): Promise<SOSAlert> {
+  if (USE_MOCK_SOS) {
+    if (!mockStore || mockStore._id !== sosId) {
+      throw new Error('No active mock SOS for that id');
+    }
+    mockStore = advanceMockStatus(mockStore);
+    return delay(mockStore, 150);
+  }
+  try {
+    const { data } = await http.get<SOSResponse>(`/sos/${sosId}`);
+    return data.sos;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const message = error.response?.data?.message;
+      throw new Error(
+        message || `Failed to fetch SOS status (${error.response?.status ?? 'unknown'})`,
+      );
+    }
+    throw new Error('Failed to fetch SOS status');
+  }
+}

--- a/guard_app/src/components/FloatingSOSButton.tsx
+++ b/guard_app/src/components/FloatingSOSButton.tsx
@@ -1,0 +1,184 @@
+// src/components/FloatingSOSButton.tsx
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Animated, Easing, Pressable, StyleSheet, Text, View, Vibration } from 'react-native';
+
+import type { RootStackParamList } from '../navigation/AppNavigator';
+
+const HOLD_DURATION_MS = 2000;
+const SIZE = 64;
+
+type Nav = NativeStackNavigationProp<RootStackParamList>;
+
+type Props = {
+  /** Optional override for hold-to-trigger duration */
+  holdDurationMs?: number;
+  /** Optional bottom offset (e.g. to clear a tab bar) */
+  bottomOffset?: number;
+  /** Optional right offset */
+  rightOffset?: number;
+};
+
+export default function FloatingSOSButton({
+  holdDurationMs = HOLD_DURATION_MS,
+  bottomOffset = 90,
+  rightOffset = 20,
+}: Props) {
+  const navigation = useNavigation<Nav>();
+
+  const [holding, setHolding] = useState(false);
+
+  const progress = useRef(new Animated.Value(0)).current;
+  const scale = useRef(new Animated.Value(1)).current;
+  const triggeredRef = useRef(false);
+
+  const reset = useCallback(() => {
+    progress.stopAnimation();
+    scale.stopAnimation();
+    Animated.parallel([
+      Animated.timing(progress, {
+        toValue: 0,
+        duration: 200,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: false,
+      }),
+      Animated.spring(scale, {
+        toValue: 1,
+        useNativeDriver: false,
+      }),
+    ]).start();
+    setHolding(false);
+    triggeredRef.current = false;
+  }, [progress, scale]);
+
+  const startHold = useCallback(() => {
+    triggeredRef.current = false;
+    setHolding(true);
+
+    Animated.spring(scale, {
+      toValue: 1.1,
+      useNativeDriver: false,
+    }).start();
+
+    Animated.timing(progress, {
+      toValue: 1,
+      duration: holdDurationMs,
+      easing: Easing.linear,
+      useNativeDriver: false,
+    }).start(({ finished }) => {
+      if (finished && !triggeredRef.current) {
+        triggeredRef.current = true;
+        Vibration.vibrate(200);
+        reset();
+        navigation.navigate('ActiveSOS');
+      }
+    });
+  }, [holdDurationMs, navigation, progress, reset, scale]);
+
+  const cancelHold = useCallback(() => {
+    if (triggeredRef.current) return;
+    reset();
+  }, [reset]);
+
+  // Cleanup if the component unmounts mid-hold
+  useEffect(() => {
+    return () => {
+      progress.stopAnimation();
+      scale.stopAnimation();
+    };
+  }, [progress, scale]);
+
+  const ringRotation = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0deg', '360deg'],
+  });
+
+  const ringOpacity = progress.interpolate({
+    inputRange: [0, 0.05, 1],
+    outputRange: [0, 1, 1],
+  });
+
+  return (
+    <View style={[styles.wrapper, { bottom: bottomOffset, right: rightOffset }]} pointerEvents="box-none">
+      {holding ? <Text style={styles.hint}>Hold to send SOS</Text> : null}
+      <Animated.View style={{ transform: [{ scale }] }}>
+        <Pressable
+          accessibilityLabel="Trigger SOS"
+          accessibilityHint="Press and hold for 2 seconds to send an emergency SOS"
+          onPressIn={startHold}
+          onPressOut={cancelHold}
+          style={({ pressed }) => [styles.button, pressed ? styles.buttonPressed : null]}
+        >
+          <Animated.View
+            pointerEvents="none"
+            style={[
+              styles.ring,
+              {
+                opacity: ringOpacity,
+                transform: [{ rotate: ringRotation }],
+              },
+            ]}
+          />
+          <Ionicons name="warning" size={26} color="#C62034" />
+          <Text style={styles.label}>SOS</Text>
+        </Pressable>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'absolute',
+    alignItems: 'flex-end',
+    zIndex: 1000,
+    elevation: 12,
+  },
+  hint: {
+    backgroundColor: 'rgba(0,0,0,0.75)',
+    color: '#FFFFFF',
+    fontSize: 12,
+    fontWeight: '600',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+    marginBottom: 6,
+    overflow: 'hidden',
+  },
+  button: {
+    width: SIZE,
+    height: SIZE,
+    borderRadius: SIZE / 2,
+    backgroundColor: 'rgba(255, 255, 255, 0.85)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOpacity: 0.12,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 5,
+    borderWidth: 2,
+    borderColor: 'rgba(198, 32, 52, 0.85)',
+  },
+  buttonPressed: {
+    backgroundColor: 'rgba(198, 32, 52, 0.92)',
+  },
+  ring: {
+    position: 'absolute',
+    width: SIZE + 12,
+    height: SIZE + 12,
+    borderRadius: (SIZE + 12) / 2,
+    borderWidth: 3,
+    borderColor: '#C62034',
+    borderTopColor: 'transparent',
+  },
+  label: {
+    color: '#C62034',
+    fontWeight: '900',
+    fontSize: 11,
+    letterSpacing: 1,
+    marginTop: 2,
+  },
+});

--- a/guard_app/src/components/FloatingSOSButton.tsx
+++ b/guard_app/src/components/FloatingSOSButton.tsx
@@ -30,8 +30,11 @@ export default function FloatingSOSButton({
 
   const [holding, setHolding] = useState(false);
 
-  const progress = useRef(new Animated.Value(0)).current;
-  const scale = useRef(new Animated.Value(1)).current;
+  // Animated values are created lazily once and remain stable across renders.
+  // Using useState (rather than useRef + .current) keeps the new
+  // react-hooks/refs lint rule happy.
+  const [progress] = useState(() => new Animated.Value(0));
+  const [scale] = useState(() => new Animated.Value(1));
   const triggeredRef = useRef(false);
 
   const reset = useCallback(() => {
@@ -101,7 +104,10 @@ export default function FloatingSOSButton({
   });
 
   return (
-    <View style={[styles.wrapper, { bottom: bottomOffset, right: rightOffset }]} pointerEvents="box-none">
+    <View
+      style={[styles.wrapper, { bottom: bottomOffset, right: rightOffset }]}
+      pointerEvents="box-none"
+    >
       {holding ? <Text style={styles.hint}>Hold to send SOS</Text> : null}
       <Animated.View style={{ transform: [{ scale }] }}>
         <Pressable

--- a/guard_app/src/navigation/AppNavigator.tsx
+++ b/guard_app/src/navigation/AppNavigator.tsx
@@ -2,6 +2,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTranslation } from 'react-i18next';
 
 import AppTabs from './AppTabs';
+import ActiveSOSScreen from '../screen/ActiveSOSScreen';
 import CertificatesScreen from '../screen/CertificatesScreen';
 import DocumentsScreen from '../screen/DocumentsScreen';
 import EditProfileScreen from '../screen/EditProfileScreen';
@@ -41,6 +42,12 @@ export type RootStackParamList = {
   Certificates: undefined;
   ShiftDetails: { shift: any };
   Terms: undefined;
+  ActiveSOS:
+    | {
+        sosId?: string;
+        emergencyContact?: { name?: string; phone?: string };
+      }
+    | undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -113,6 +120,19 @@ export default function AppNavigator() {
         name="Terms"
         component={TermsScreen}
         options={{ headerShown: true, title: 'Terms of Service' }}
+      />
+      <Stack.Screen
+        name="ActiveSOS"
+        component={ActiveSOSScreen}
+        options={{
+          headerShown: true,
+          title: 'Emergency Active',
+          headerStyle: { backgroundColor: '#B00020' },
+          headerTintColor: '#FFFFFF',
+          headerTitleStyle: { color: '#FFFFFF', fontWeight: '700' },
+          headerBackVisible: false,
+          gestureEnabled: false,
+        }}
       />
     </Stack.Navigator>
   );

--- a/guard_app/src/navigation/AppTabs.tsx
+++ b/guard_app/src/navigation/AppTabs.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 import FloatingSOSButton from '../components/FloatingSOSButton';
 import AvailabilityScreen from '../screen/AvailabilityScreen';
@@ -29,7 +29,7 @@ export default function AppTabs() {
   const { t } = useTranslation();
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={styles.root}>
       <Tab.Navigator
         screenOptions={({ route }) => ({
           headerShown: true,
@@ -99,3 +99,9 @@ export default function AppTabs() {
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+});

--- a/guard_app/src/navigation/AppTabs.tsx
+++ b/guard_app/src/navigation/AppTabs.tsx
@@ -1,7 +1,10 @@
 import { Ionicons } from '@expo/vector-icons';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { View } from 'react-native';
 
+import FloatingSOSButton from '../components/FloatingSOSButton';
 import AvailabilityScreen from '../screen/AvailabilityScreen';
 import DocumentsScreen from '../screen/DocumentsScreen';
 import HomeScreen from '../screen/HomeScreen';
@@ -26,70 +29,73 @@ export default function AppTabs() {
   const { t } = useTranslation();
 
   return (
-    <Tab.Navigator
-      screenOptions={({ route }) => ({
-        headerShown: true,
-        headerStyle: {
-          backgroundColor: colors.card,
-        },
-        headerTitleStyle: {
-          color: colors.text,
-        },
-        headerTintColor: colors.text,
-        tabBarStyle: {
-          backgroundColor: colors.card,
-          borderTopColor: colors.border,
-        },
-        tabBarIcon: ({ color, size }) => {
-          const name =
-            route.name === 'Home'
-              ? ('home-outline' as const)
-              : route.name === 'Shifts'
-                ? ('briefcase-outline' as const)
-                : route.name === 'Availability'
-                  ? ('calendar-outline' as const)
-                  : route.name === 'Documents'
-                    ? ('folder-outline' as const)
-                    : route.name === 'Timesheets'
-                      ? ('clipboard-outline' as const)
-                      : ('person-outline' as const);
+    <View style={{ flex: 1 }}>
+      <Tab.Navigator
+        screenOptions={({ route }) => ({
+          headerShown: true,
+          headerStyle: {
+            backgroundColor: colors.card,
+          },
+          headerTitleStyle: {
+            color: colors.text,
+          },
+          headerTintColor: colors.text,
+          tabBarStyle: {
+            backgroundColor: colors.card,
+            borderTopColor: colors.border,
+          },
+          tabBarIcon: ({ color, size }) => {
+            const name =
+              route.name === 'Home'
+                ? ('home-outline' as const)
+                : route.name === 'Shifts'
+                  ? ('briefcase-outline' as const)
+                  : route.name === 'Availability'
+                    ? ('calendar-outline' as const)
+                    : route.name === 'Documents'
+                      ? ('folder-outline' as const)
+                      : route.name === 'Timesheets'
+                        ? ('clipboard-outline' as const)
+                        : ('person-outline' as const);
 
-          return <Ionicons name={name} size={size} color={color} />;
-        },
-        tabBarActiveTintColor: colors.primary,
-        tabBarInactiveTintColor: colors.muted,
-      })}
-    >
-      <Tab.Screen
-        name="Home"
-        component={HomeScreen}
-        options={{ tabBarLabel: t('tabs.home'), headerTitle: t('tabs.home') }}
-      />
-      <Tab.Screen
-        name="Shifts"
-        component={ShiftsScreen}
-        options={{ tabBarLabel: t('tabs.shifts'), headerTitle: t('tabs.shifts') }}
-      />
-      <Tab.Screen
-        name="Availability"
-        component={AvailabilityScreen}
-        options={{ tabBarLabel: t('tabs.availability'), headerTitle: t('tabs.availability') }}
-      />
-      <Tab.Screen
-        name="Documents"
-        component={DocumentsScreen}
-        options={{ tabBarLabel: t('tabs.documents'), headerTitle: t('tabs.documents') }}
-      />
-      <Tab.Screen
-        name="Timesheets"
-        component={TimesheetsScreen}
-        options={{ tabBarLabel: t('tabs.timesheets'), headerTitle: t('tabs.timesheets') }}
-      />
-      <Tab.Screen
-        name="Profile"
-        component={ProfileScreen}
-        options={{ tabBarLabel: t('tabs.profile'), headerTitle: t('tabs.profile') }}
-      />
-    </Tab.Navigator>
+            return <Ionicons name={name} size={size} color={color} />;
+          },
+          tabBarActiveTintColor: colors.primary,
+          tabBarInactiveTintColor: colors.muted,
+        })}
+      >
+        <Tab.Screen
+          name="Home"
+          component={HomeScreen}
+          options={{ tabBarLabel: t('tabs.home'), headerTitle: t('tabs.home') }}
+        />
+        <Tab.Screen
+          name="Shifts"
+          component={ShiftsScreen}
+          options={{ tabBarLabel: t('tabs.shifts'), headerTitle: t('tabs.shifts') }}
+        />
+        <Tab.Screen
+          name="Availability"
+          component={AvailabilityScreen}
+          options={{ tabBarLabel: t('tabs.availability'), headerTitle: t('tabs.availability') }}
+        />
+        <Tab.Screen
+          name="Documents"
+          component={DocumentsScreen}
+          options={{ tabBarLabel: t('tabs.documents'), headerTitle: t('tabs.documents') }}
+        />
+        <Tab.Screen
+          name="Timesheets"
+          component={TimesheetsScreen}
+          options={{ tabBarLabel: t('tabs.timesheets'), headerTitle: t('tabs.timesheets') }}
+        />
+        <Tab.Screen
+          name="Profile"
+          component={ProfileScreen}
+          options={{ tabBarLabel: t('tabs.profile'), headerTitle: t('tabs.profile') }}
+        />
+      </Tab.Navigator>
+      <FloatingSOSButton />
+    </View>
   );
 }

--- a/guard_app/src/screen/ActiveSOSScreen.tsx
+++ b/guard_app/src/screen/ActiveSOSScreen.tsx
@@ -161,39 +161,36 @@ export default function ActiveSOSScreen() {
    * Start watching position and push updates to the backend at most every
    * LOCATION_PUSH_INTERVAL_MS or every LOCATION_DISTANCE_INTERVAL_M metres.
    */
-  const startLocationWatcher = useCallback(
-    async (activeSosId: string) => {
-      if (watcherRef.current) return;
-      try {
-        const sub = await Location.watchPositionAsync(
-          {
-            accuracy: Location.Accuracy.High,
-            timeInterval: LOCATION_PUSH_INTERVAL_MS,
-            distanceInterval: LOCATION_DISTANCE_INTERVAL_M,
-          },
-          (loc) => {
-            const next: Coords = {
-              latitude: loc.coords.latitude,
-              longitude: loc.coords.longitude,
-              timestamp: loc.timestamp,
-            };
-            setCoords(next);
-            const now = Date.now();
-            if (now - lastPushedAtRef.current >= LOCATION_PUSH_INTERVAL_MS) {
-              lastPushedAtRef.current = now;
-              updateSOSLocation(activeSosId, next).catch(() => {
-                // best-effort; ignore individual push failures
-              });
-            }
-          },
-        );
-        watcherRef.current = sub;
-      } catch {
-        // location watcher is best effort
-      }
-    },
-    [],
-  );
+  const startLocationWatcher = useCallback(async (activeSosId: string) => {
+    if (watcherRef.current) return;
+    try {
+      const sub = await Location.watchPositionAsync(
+        {
+          accuracy: Location.Accuracy.High,
+          timeInterval: LOCATION_PUSH_INTERVAL_MS,
+          distanceInterval: LOCATION_DISTANCE_INTERVAL_M,
+        },
+        (loc) => {
+          const next: Coords = {
+            latitude: loc.coords.latitude,
+            longitude: loc.coords.longitude,
+            timestamp: loc.timestamp,
+          };
+          setCoords(next);
+          const now = Date.now();
+          if (now - lastPushedAtRef.current >= LOCATION_PUSH_INTERVAL_MS) {
+            lastPushedAtRef.current = now;
+            updateSOSLocation(activeSosId, next).catch(() => {
+              // best-effort; ignore individual push failures
+            });
+          }
+        },
+      );
+      watcherRef.current = sub;
+    } catch {
+      // location watcher is best effort
+    }
+  }, []);
 
   const stopLocationWatcher = useCallback(() => {
     if (watcherRef.current) {
@@ -258,8 +255,7 @@ export default function ActiveSOSScreen() {
           setStatus(existing.status);
           setTriggeredAt(existing.triggeredAt);
           setCoords(existing.location);
-          cancelDeadlineRef.current =
-            new Date(existing.triggeredAt).getTime() + CANCEL_GRACE_MS;
+          cancelDeadlineRef.current = new Date(existing.triggeredAt).getTime() + CANCEL_GRACE_MS;
           setBootstrapping(false);
           startPolling(initialSosId);
           startLocationWatcher(initialSosId);
@@ -278,8 +274,7 @@ export default function ActiveSOSScreen() {
           setSosId(created._id);
           setStatus(created.status);
           setTriggeredAt(created.triggeredAt);
-          cancelDeadlineRef.current =
-            new Date(created.triggeredAt).getTime() + CANCEL_GRACE_MS;
+          cancelDeadlineRef.current = new Date(created.triggeredAt).getTime() + CANCEL_GRACE_MS;
           setBootstrapping(false);
           startPolling(created._id);
           startLocationWatcher(created._id);
@@ -316,7 +311,9 @@ export default function ActiveSOSScreen() {
     return () => stopCancelTimer();
   }, [stopCancelTimer]);
 
-  const canQuickCancel = cancelRemainingMs > 0 && (status === 'pending' || status === 'notifying' || status === 'notified');
+  const canQuickCancel =
+    cancelRemainingMs > 0 &&
+    (status === 'pending' || status === 'notifying' || status === 'notified');
   const canConfirmCancel = !canQuickCancel && status !== 'cancelled' && status !== 'resolved';
 
   const performCancel = useCallback(async () => {
@@ -391,10 +388,8 @@ export default function ActiveSOSScreen() {
 
   const cancelSecondsRemaining = Math.ceil(cancelRemainingMs / 1000);
 
-  const contactLabel =
-    alert?.emergencyContact?.name ?? initialContactName ?? 'Emergency Contact';
-  const contactPhone =
-    alert?.emergencyContact?.phone ?? initialContactPhone ?? '000';
+  const contactLabel = alert?.emergencyContact?.name ?? initialContactName ?? 'Emergency Contact';
+  const contactPhone = alert?.emergencyContact?.phone ?? initialContactPhone ?? '000';
 
   return (
     <View style={s.screen}>
@@ -455,15 +450,13 @@ export default function ActiveSOSScreen() {
             <Text style={s.btnText}>{alert?.note ? 'Update Note' : 'Add Note'}</Text>
           </TouchableOpacity>
 
-          {(canQuickCancel || canConfirmCancel) ? (
+          {canQuickCancel || canConfirmCancel ? (
             <TouchableOpacity
               style={[s.btn, canQuickCancel ? s.cancelQuickBtn : s.cancelConfirmBtn]}
               onPress={handleCancelPress}
             >
               <Text style={s.btnText}>
-                {canQuickCancel
-                  ? `Cancel SOS (${cancelSecondsRemaining}s)`
-                  : 'Cancel SOS'}
+                {canQuickCancel ? `Cancel SOS (${cancelSecondsRemaining}s)` : 'Cancel SOS'}
               </Text>
             </TouchableOpacity>
           ) : null}

--- a/guard_app/src/screen/ActiveSOSScreen.tsx
+++ b/guard_app/src/screen/ActiveSOSScreen.tsx
@@ -1,0 +1,718 @@
+// src/screen/ActiveSOSScreen.tsx
+import { Ionicons } from '@expo/vector-icons';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import * as Location from 'expo-location';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Linking,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import {
+  addSOSNote,
+  cancelSOS,
+  getSOSStatus,
+  SOSAlert,
+  SOSStatus,
+  triggerSOS,
+  updateSOSLocation,
+} from '../api/sos';
+import ErrorMessageBox from '../components/ErrorMessageBox';
+import { useAppTheme } from '../theme';
+
+import type { RootStackParamList } from '../navigation/AppNavigator';
+
+type ScreenRouteProp = RouteProp<RootStackParamList, 'ActiveSOS'>;
+type Nav = NativeStackNavigationProp<RootStackParamList>;
+
+const CANCEL_GRACE_MS = 10_000;
+const STATUS_POLL_MS = 5_000;
+const LOCATION_PUSH_INTERVAL_MS = 15_000;
+const LOCATION_DISTANCE_INTERVAL_M = 10;
+
+type Coords = {
+  latitude: number;
+  longitude: number;
+  timestamp?: number;
+};
+
+const STATUS_LABELS: Record<SOSStatus, string> = {
+  pending: 'Sending SOS...',
+  notifying: 'Notifying supervisor',
+  notified: 'Supervisor notified',
+  connected: 'Connected — help on the way',
+  cancelled: 'SOS cancelled',
+  resolved: 'SOS resolved',
+};
+
+function formatTime(iso?: string) {
+  if (!iso) return '--:--:--';
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString();
+  } catch {
+    return '--:--:--';
+  }
+}
+
+function formatCoord(value?: number) {
+  if (typeof value !== 'number') return '—';
+  return value.toFixed(5);
+}
+
+export default function ActiveSOSScreen() {
+  const route = useRoute<ScreenRouteProp>();
+  const navigation = useNavigation<Nav>();
+  const { colors } = useAppTheme();
+  const s = useMemo(() => getStyles(colors), [colors]);
+
+  const initialSosId = route.params?.sosId;
+  const initialContactPhone = route.params?.emergencyContact?.phone;
+  const initialContactName = route.params?.emergencyContact?.name;
+
+  const [sosId, setSosId] = useState<string | null>(initialSosId ?? null);
+  const [alert, setAlert] = useState<SOSAlert | null>(null);
+  const [coords, setCoords] = useState<Coords | null>(null);
+  const [triggeredAt, setTriggeredAt] = useState<string | null>(null);
+  const [status, setStatus] = useState<SOSStatus>('pending');
+  const [errorState, setErrorState] = useState<{ title: string; message: string } | null>(null);
+  const [bootstrapping, setBootstrapping] = useState(true);
+  const [cancelRemainingMs, setCancelRemainingMs] = useState(CANCEL_GRACE_MS);
+  const [noteVisible, setNoteVisible] = useState(false);
+  const [noteDraft, setNoteDraft] = useState('');
+  const [noteSaving, setNoteSaving] = useState(false);
+
+  const watcherRef = useRef<Location.LocationSubscription | null>(null);
+  const lastPushedAtRef = useRef<number>(0);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const cancelTickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const cancelDeadlineRef = useRef<number>(Date.now() + CANCEL_GRACE_MS);
+  const mountedRef = useRef(true);
+
+  const closeError = useCallback(() => setErrorState(null), []);
+
+  const showError = useCallback((title: string, message: string) => {
+    setErrorState({ title, message });
+  }, []);
+
+  /**
+   * Try to grab a single fix to start with (for triggering or for the initial
+   * location indicator). Returns null on failure.
+   */
+  const fetchInitialPosition = useCallback(async (): Promise<Coords | null> => {
+    try {
+      const servicesEnabled = await Location.hasServicesEnabledAsync();
+      if (!servicesEnabled) {
+        showError(
+          'Location services are off',
+          'Turn on location services in Settings so we can share your live location with responders.',
+        );
+        return null;
+      }
+      let perm = await Location.getForegroundPermissionsAsync();
+      if (perm.status !== 'granted') {
+        perm = await Location.requestForegroundPermissionsAsync();
+      }
+      if (perm.status !== 'granted') {
+        showError(
+          'Location permission required',
+          'SOS needs location permission to share your live position with responders.',
+        );
+        return null;
+      }
+      if (Platform.OS === 'android') {
+        try {
+          await Location.enableNetworkProviderAsync();
+        } catch {
+          // ignore
+        }
+      }
+      const fix = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
+      return {
+        latitude: fix.coords.latitude,
+        longitude: fix.coords.longitude,
+        timestamp: fix.timestamp,
+      };
+    } catch {
+      const last = await Location.getLastKnownPositionAsync().catch(() => null);
+      if (last) {
+        return {
+          latitude: last.coords.latitude,
+          longitude: last.coords.longitude,
+          timestamp: last.timestamp,
+        };
+      }
+      return null;
+    }
+  }, [showError]);
+
+  /**
+   * Start watching position and push updates to the backend at most every
+   * LOCATION_PUSH_INTERVAL_MS or every LOCATION_DISTANCE_INTERVAL_M metres.
+   */
+  const startLocationWatcher = useCallback(
+    async (activeSosId: string) => {
+      if (watcherRef.current) return;
+      try {
+        const sub = await Location.watchPositionAsync(
+          {
+            accuracy: Location.Accuracy.High,
+            timeInterval: LOCATION_PUSH_INTERVAL_MS,
+            distanceInterval: LOCATION_DISTANCE_INTERVAL_M,
+          },
+          (loc) => {
+            const next: Coords = {
+              latitude: loc.coords.latitude,
+              longitude: loc.coords.longitude,
+              timestamp: loc.timestamp,
+            };
+            setCoords(next);
+            const now = Date.now();
+            if (now - lastPushedAtRef.current >= LOCATION_PUSH_INTERVAL_MS) {
+              lastPushedAtRef.current = now;
+              updateSOSLocation(activeSosId, next).catch(() => {
+                // best-effort; ignore individual push failures
+              });
+            }
+          },
+        );
+        watcherRef.current = sub;
+      } catch {
+        // location watcher is best effort
+      }
+    },
+    [],
+  );
+
+  const stopLocationWatcher = useCallback(() => {
+    if (watcherRef.current) {
+      watcherRef.current.remove();
+      watcherRef.current = null;
+    }
+  }, []);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const stopCancelTimer = useCallback(() => {
+    if (cancelTickRef.current) {
+      clearInterval(cancelTickRef.current);
+      cancelTickRef.current = null;
+    }
+  }, []);
+
+  /**
+   * Start polling backend for status changes once we have a sosId.
+   */
+  const startPolling = useCallback(
+    (activeSosId: string) => {
+      stopPolling();
+      pollRef.current = setInterval(async () => {
+        try {
+          const next = await getSOSStatus(activeSosId);
+          if (!mountedRef.current) return;
+          setAlert(next);
+          setStatus(next.status);
+          if (next.status === 'cancelled' || next.status === 'resolved') {
+            stopPolling();
+            stopLocationWatcher();
+          }
+        } catch {
+          // ignore poll failures
+        }
+      }, STATUS_POLL_MS);
+    },
+    [stopLocationWatcher, stopPolling],
+  );
+
+  /**
+   * Bootstrap: either resume an existing SOS (sosId in params) or trigger
+   * a new one using the current location.
+   */
+  useEffect(() => {
+    mountedRef.current = true;
+    let active = true;
+
+    (async () => {
+      try {
+        if (initialSosId) {
+          // Resume an existing SOS
+          const existing = await getSOSStatus(initialSosId);
+          if (!active) return;
+          setAlert(existing);
+          setStatus(existing.status);
+          setTriggeredAt(existing.triggeredAt);
+          setCoords(existing.location);
+          cancelDeadlineRef.current =
+            new Date(existing.triggeredAt).getTime() + CANCEL_GRACE_MS;
+          setBootstrapping(false);
+          startPolling(initialSosId);
+          startLocationWatcher(initialSosId);
+        } else {
+          // Trigger a new SOS
+          const fix = await fetchInitialPosition();
+          if (!active) return;
+          if (!fix) {
+            setBootstrapping(false);
+            return;
+          }
+          setCoords(fix);
+          const created = await triggerSOS(fix);
+          if (!active) return;
+          setAlert(created);
+          setSosId(created._id);
+          setStatus(created.status);
+          setTriggeredAt(created.triggeredAt);
+          cancelDeadlineRef.current =
+            new Date(created.triggeredAt).getTime() + CANCEL_GRACE_MS;
+          setBootstrapping(false);
+          startPolling(created._id);
+          startLocationWatcher(created._id);
+        }
+      } catch (e: unknown) {
+        if (!active) return;
+        const msg = e instanceof Error ? e.message : 'Could not activate SOS';
+        showError('Unable to activate SOS', msg);
+        setBootstrapping(false);
+      }
+    })();
+
+    return () => {
+      active = false;
+      mountedRef.current = false;
+      stopPolling();
+      stopLocationWatcher();
+      stopCancelTimer();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /**
+   * Tick the cancel-grace countdown so the user sees seconds remaining.
+   */
+  useEffect(() => {
+    cancelTickRef.current = setInterval(() => {
+      const remaining = Math.max(0, cancelDeadlineRef.current - Date.now());
+      setCancelRemainingMs(remaining);
+      if (remaining <= 0) {
+        stopCancelTimer();
+      }
+    }, 250);
+    return () => stopCancelTimer();
+  }, [stopCancelTimer]);
+
+  const canQuickCancel = cancelRemainingMs > 0 && (status === 'pending' || status === 'notifying' || status === 'notified');
+  const canConfirmCancel = !canQuickCancel && status !== 'cancelled' && status !== 'resolved';
+
+  const performCancel = useCallback(async () => {
+    if (!sosId) {
+      navigation.goBack();
+      return;
+    }
+    try {
+      const next = await cancelSOS(sosId);
+      setAlert(next);
+      setStatus(next.status);
+      stopPolling();
+      stopLocationWatcher();
+      Alert.alert('SOS cancelled', 'Your SOS has been cancelled.');
+      navigation.goBack();
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Could not cancel SOS';
+      showError('Cancel failed', msg);
+    }
+  }, [navigation, showError, sosId, stopLocationWatcher, stopPolling]);
+
+  const handleCancelPress = useCallback(() => {
+    if (canQuickCancel) {
+      void performCancel();
+      return;
+    }
+    Alert.alert(
+      'Cancel SOS?',
+      'Cancelling will tell responders you no longer need help. Are you sure?',
+      [
+        { text: 'Keep active', style: 'cancel' },
+        { text: 'Cancel SOS', style: 'destructive', onPress: () => void performCancel() },
+      ],
+    );
+  }, [canQuickCancel, performCancel]);
+
+  const handleCallEmergency = useCallback(async () => {
+    const phone = alert?.emergencyContact?.phone ?? initialContactPhone ?? '000';
+    const url = `tel:${phone}`;
+    try {
+      // Try to open the dialer directly. We skip Linking.canOpenURL because
+      // some emulators report tel: as unsupported even when a dialer exists.
+      await Linking.openURL(url);
+    } catch {
+      showError(
+        'Cannot place call',
+        `We could not start a call to ${phone}. If you're on an emulator, try a real device.`,
+      );
+    }
+  }, [alert?.emergencyContact?.phone, initialContactPhone, showError]);
+
+  const handleSaveNote = useCallback(async () => {
+    if (!sosId) return;
+    const trimmed = noteDraft.trim();
+    if (!trimmed) {
+      setNoteVisible(false);
+      return;
+    }
+    try {
+      setNoteSaving(true);
+      const next = await addSOSNote(sosId, trimmed);
+      setAlert(next);
+      setNoteVisible(false);
+      setNoteDraft('');
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Could not save note';
+      showError('Note failed', msg);
+    } finally {
+      setNoteSaving(false);
+    }
+  }, [noteDraft, showError, sosId]);
+
+  const cancelSecondsRemaining = Math.ceil(cancelRemainingMs / 1000);
+
+  const contactLabel =
+    alert?.emergencyContact?.name ?? initialContactName ?? 'Emergency Contact';
+  const contactPhone =
+    alert?.emergencyContact?.phone ?? initialContactPhone ?? '000';
+
+  return (
+    <View style={s.screen}>
+      <ScrollView contentContainerStyle={s.content}>
+        <View style={s.banner}>
+          <Ionicons name="warning" size={42} color="#FFFFFF" />
+          <Text style={s.bannerTitle}>EMERGENCY ACTIVE</Text>
+          <Text style={s.bannerSubtitle}>SOS Sent</Text>
+        </View>
+
+        <View style={s.card}>
+          <View style={s.row}>
+            <Ionicons name="time-outline" size={20} color={colors.muted} />
+            <Text style={s.rowLabel}>Triggered</Text>
+            <Text style={s.rowValue}>{formatTime(triggeredAt ?? alert?.triggeredAt)}</Text>
+          </View>
+
+          <View style={s.row}>
+            <Ionicons name="pulse-outline" size={20} color={colors.muted} />
+            <Text style={s.rowLabel}>Status</Text>
+            <View style={s.statusValueWrap}>
+              {bootstrapping ? <ActivityIndicator size="small" color="#B00020" /> : null}
+              <Text style={[s.rowValue, s.statusValue]}>{STATUS_LABELS[status]}</Text>
+            </View>
+          </View>
+
+          {alert?.statusMessage ? <Text style={s.statusMessage}>{alert.statusMessage}</Text> : null}
+        </View>
+
+        <View style={s.card}>
+          <View style={s.locHeader}>
+            <Ionicons name="location" size={20} color="#B00020" />
+            <Text style={s.locHeaderText}>Sharing live location</Text>
+          </View>
+          <Text style={s.coords}>
+            {formatCoord(coords?.latitude)}, {formatCoord(coords?.longitude)}
+          </Text>
+          <Text style={s.coordsHint}>
+            Updates every {Math.round(LOCATION_PUSH_INTERVAL_MS / 1000)}s while SOS is active.
+          </Text>
+        </View>
+
+        <View style={s.actions}>
+          <TouchableOpacity style={[s.btn, s.callBtn]} onPress={handleCallEmergency}>
+            <Ionicons name="call" size={22} color="#FFFFFF" />
+            <Text style={s.btnText}>Call {contactLabel}</Text>
+          </TouchableOpacity>
+          <Text style={s.callHint}>{contactPhone}</Text>
+
+          <TouchableOpacity
+            style={[s.btn, s.noteBtn]}
+            onPress={() => {
+              setNoteDraft(alert?.note ?? '');
+              setNoteVisible(true);
+            }}
+          >
+            <Ionicons name="create-outline" size={22} color="#FFFFFF" />
+            <Text style={s.btnText}>{alert?.note ? 'Update Note' : 'Add Note'}</Text>
+          </TouchableOpacity>
+
+          {(canQuickCancel || canConfirmCancel) ? (
+            <TouchableOpacity
+              style={[s.btn, canQuickCancel ? s.cancelQuickBtn : s.cancelConfirmBtn]}
+              onPress={handleCancelPress}
+            >
+              <Text style={s.btnText}>
+                {canQuickCancel
+                  ? `Cancel SOS (${cancelSecondsRemaining}s)`
+                  : 'Cancel SOS'}
+              </Text>
+            </TouchableOpacity>
+          ) : null}
+
+          {!canQuickCancel && status !== 'cancelled' && status !== 'resolved' ? (
+            <Text style={s.graceHint}>
+              Quick cancel window has ended. Tap Cancel SOS to confirm.
+            </Text>
+          ) : null}
+        </View>
+      </ScrollView>
+
+      <Modal
+        visible={noteVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setNoteVisible(false)}
+      >
+        <View style={s.modalOverlay}>
+          <View style={s.modalCard}>
+            <Text style={s.modalTitle}>Update situation</Text>
+            <TextInput
+              style={s.modalInput}
+              value={noteDraft}
+              onChangeText={setNoteDraft}
+              placeholder="Describe what's happening..."
+              placeholderTextColor={colors.muted}
+              multiline
+              textAlignVertical="top"
+            />
+            <View style={s.modalActions}>
+              <Pressable style={s.modalBtnSecondary} onPress={() => setNoteVisible(false)}>
+                <Text style={s.modalBtnSecondaryText}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                style={[s.modalBtnPrimary, noteSaving ? s.modalBtnDisabled : null]}
+                disabled={noteSaving}
+                onPress={() => void handleSaveNote()}
+              >
+                {noteSaving ? (
+                  <ActivityIndicator size="small" color="#FFFFFF" />
+                ) : (
+                  <Text style={s.modalBtnPrimaryText}>Save</Text>
+                )}
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
+
+      <ErrorMessageBox
+        visible={Boolean(errorState)}
+        title={errorState?.title}
+        message={errorState?.message}
+        onClose={closeError}
+      />
+    </View>
+  );
+}
+
+const getStyles = (colors: ReturnType<typeof useAppTheme>['colors']) =>
+  StyleSheet.create({
+    screen: {
+      flex: 1,
+      backgroundColor: '#1A0000',
+    },
+    content: {
+      padding: 16,
+      paddingBottom: 32,
+    },
+    banner: {
+      backgroundColor: '#B00020',
+      borderRadius: 16,
+      padding: 24,
+      alignItems: 'center',
+      marginBottom: 16,
+      borderWidth: 2,
+      borderColor: '#FF3B3B',
+    },
+    bannerTitle: {
+      color: '#FFFFFF',
+      fontSize: 26,
+      fontWeight: '900',
+      marginTop: 8,
+      letterSpacing: 1,
+    },
+    bannerSubtitle: {
+      color: '#FFD9DD',
+      fontSize: 16,
+      fontWeight: '600',
+      marginTop: 4,
+    },
+    card: {
+      backgroundColor: colors.card,
+      borderRadius: 12,
+      padding: 16,
+      marginBottom: 16,
+      borderWidth: 1,
+      borderColor: colors.border,
+    },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 12,
+    },
+    rowLabel: {
+      marginLeft: 10,
+      flex: 1,
+      fontSize: 15,
+      color: colors.muted,
+      fontWeight: '600',
+    },
+    rowValue: {
+      fontSize: 15,
+      color: colors.text,
+      fontWeight: '700',
+    },
+    statusValueWrap: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+    },
+    statusValue: {
+      color: '#B00020',
+    },
+    statusMessage: {
+      color: colors.muted,
+      fontSize: 14,
+      marginTop: 4,
+    },
+    locHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 8,
+    },
+    locHeaderText: {
+      marginLeft: 8,
+      color: '#B00020',
+      fontWeight: '700',
+      fontSize: 16,
+    },
+    coords: {
+      color: colors.text,
+      fontSize: 16,
+      fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace', default: 'monospace' }),
+    },
+    coordsHint: {
+      color: colors.muted,
+      fontSize: 12,
+      marginTop: 6,
+    },
+    actions: {
+      marginTop: 4,
+    },
+    btn: {
+      flexDirection: 'row',
+      gap: 8,
+      paddingVertical: 16,
+      borderRadius: 12,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginBottom: 12,
+    },
+    callBtn: {
+      backgroundColor: '#B00020',
+    },
+    noteBtn: {
+      backgroundColor: '#244B7A',
+    },
+    cancelQuickBtn: {
+      backgroundColor: '#9E9E9E',
+    },
+    cancelConfirmBtn: {
+      backgroundColor: '#4B5563',
+    },
+    btnText: {
+      color: '#FFFFFF',
+      fontSize: 17,
+      fontWeight: '700',
+    },
+    callHint: {
+      color: '#FFD9DD',
+      textAlign: 'center',
+      marginTop: -6,
+      marginBottom: 12,
+    },
+    graceHint: {
+      color: '#FFD9DD',
+      textAlign: 'center',
+      fontSize: 13,
+    },
+    modalOverlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.6)',
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 20,
+    },
+    modalCard: {
+      width: '100%',
+      backgroundColor: colors.card,
+      borderRadius: 16,
+      padding: 20,
+      borderWidth: 1,
+      borderColor: colors.border,
+    },
+    modalTitle: {
+      fontSize: 18,
+      fontWeight: '700',
+      color: colors.text,
+      marginBottom: 12,
+    },
+    modalInput: {
+      minHeight: 100,
+      borderWidth: 1,
+      borderColor: colors.border,
+      borderRadius: 10,
+      padding: 12,
+      color: colors.text,
+      fontSize: 15,
+      marginBottom: 16,
+    },
+    modalActions: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      gap: 12,
+    },
+    modalBtnSecondary: {
+      paddingVertical: 10,
+      paddingHorizontal: 16,
+      borderRadius: 8,
+    },
+    modalBtnSecondaryText: {
+      color: colors.muted,
+      fontWeight: '600',
+    },
+    modalBtnPrimary: {
+      backgroundColor: '#B00020',
+      paddingVertical: 10,
+      paddingHorizontal: 20,
+      borderRadius: 8,
+      minWidth: 80,
+      alignItems: 'center',
+    },
+    modalBtnDisabled: {
+      opacity: 0.7,
+    },
+    modalBtnPrimaryText: {
+      color: '#FFFFFF',
+      fontWeight: '700',
+    },
+  });


### PR DESCRIPTION
## What this PR adds
Implements the Active SOS State Screen per the user story.

### New files
- `guard_app/src/screen/ActiveSOSScreen.tsx` — full-screen emergency view
- `guard_app/src/components/FloatingSOSButton.tsx` — long-press FAB on tab screens
- `guard_app/src/api/sos.ts` — SOS API client (mocked for now)

### Modified
- `guard_app/src/navigation/AppNavigator.tsx` — registers ActiveSOS route
- `guard_app/src/navigation/AppTabs.tsx` — mounts the floating SOS button

### Features covered
- ✅ Emergency status indicator (red banner, "EMERGENCY ACTIVE / SOS Sent")
- ✅ Live status info (timestamp + status with progression: pending → notifying → notified → connected)
- ✅ Location sharing indicator (live coordinates, updates every 15s)
- ✅ Emergency actions (call contact, add/update note)
- ✅ 10s cancel grace period (instant during, confirmation after)
- ✅ Long-press trigger (2s hold) with progress ring + haptic feedback

### Backend dependency
The screen is wired to the real `/sos/*` endpoints but currently uses a frontend mock (`USE_MOCK_SOS = true` in `src/api/sos.ts`) since the backend routes don't exist yet. Flip the flag to `false` once the backend has `POST /sos/trigger`, `POST /sos/:id/cancel`, `POST /sos/:id/location`, `POST /sos/:id/note`, `GET /sos/:id`.

### Testing
1. `npx expo start -c`
2. From any tab, press and hold the red SOS button (bottom-right) for 2 seconds
3. Verify the active screen renders with timestamp, status updates, live coords
4. Test cancel within and after the 10s grace period
5. Test the note modal and call button (call requires a real device for emergency numbers)


<img width="350" height="802" alt="Screenshot 2026-04-30 at 
<img width="350" height="812" alt="Screenshot 2026-04-30 at 8 41 05 pm" src="https://github.com/user-attachments/assets/de0ac20f-
<img width="350" height="812" alt="Screensh
<img width="349" height="809" alt="Screenshot 2026-04-30 at 9 00 33 pm" src="https://github.com/user-attachments/assets/494bcde8-991c-4c16-a638-4b2bfb83c556" />
<img width="350" height="812" alt="Screenshot 2026-04-30 at 8 42 46 pm" src="https://github.com/user-attachments/assets/bdde5275-1d05-4f9d-9d3b-aad509670ec6" />

<img width="350" height="812" alt="Screenshot 2026-04-30 at 8 40 44 pm" src="https://github.com/user-attachments/assets/cdbc92df-0499-4775-9ac6-88844f102e89" />
ot 2026-04-30 at 8 42 38 pm" src="https://github.com/user-attachments/assets/1195c469-f311-4413-9087-64121bb444a4" />
<img width="350" height="812" alt="Screenshot 2026-04-30 at 8 40 38 pm" src="https://github.com/user-attachments/assets/9bfc585f-10ff-4cec-9955-4a51e15e65b8" />

bccb-4b77-b9dd-eae5034a7d6e" />
8 55 22 pm" src="https://github.com/user-attachments/assets/033e7
<img width="350" height="812" alt="Screenshot 2026-04-30 at 8 40 23 pm" src="https://github.com/user-attachments/assets/276d9e5c-0632-42b5-b0ff-b87107c54cb2" />
2d4-e4ad-47ca-b95d-0a61b6b58a4c" />
 