### PR TITLE
Fix: Create Shift bug

### DIFF
--- a/app-frontend/employer-panel/src/pages/createShift.js
+++ b/app-frontend/employer-panel/src/pages/createShift.js
@@ -433,6 +433,7 @@ const CreateShift = ({ isModal = false, onClose }) => {
       shiftType: values.shiftType === 'day' ? 'Day' : 'Night',
       description: values.instructions,
       guards: values.guards || [],
+      status:"open",
       location: (() => {
         const parsed = parseAddress(selectedSite?.address || values.location);
         return {


### PR DESCRIPTION
Fix: Shifts created as draft instead of open
Problem
When an employer created a shift through the Create Shift form, the shift was being saved to the database as draft despite appearing as open in the UI. This caused newly created shifts to be invisible to guards browsing available shifts.
Root Cause
The status field was never included in the API payload inside onSubmit in CreateShift.js. The backend defaults to 'draft' when no status is provided, so every shift created through the form landed as a draft regardless of intent.
Fix
Added status: 'open' to the payload in the onSubmit handler in CreateShift.js.
## Screenshots
<img width="1894" height="996" alt="Screenshot 2026-05-01 132455" src="https://github.com/user-attachments/assets/53398b2a-d9b4-4900-8cd4-7b0b4435be82" />
<img width="1914" height="1005" alt="Screenshot 2026-05-01 132527" src="https://github.com/user-attachments/assets/d65f88d4-b1b4-4aa6-8215-75feee4cc33e" />
<img width="1899" height="873" alt="Screenshot 2026-05-01 132551" src="https://github.com/user-attachments/assets/c4133c80-70ca-41b3-9345-7e56be0435fa" />
<img width="1919" height="883" alt="Screenshot 2026-05-01 132605" src="https://github.com/user-attachments/assets/9bd261e0-95d2-45c0-8a92-f17653e86681" />