### PR TITLE
fix: attach navigationRef to fix Login redirect on jwt expiry

### DIFF
--- a/guard_app/App.tsx
+++ b/guard_app/App.tsx
@@ -66,7 +66,7 @@ function AppContent() {
   };
 
   return (
-    <NavigationContainer theme={navigationTheme}>
+    <NavigationContainer theme={navigationTheme} ref={navigationRef}>
       <AppNavigator />
     </NavigationContainer>
   );


### PR DESCRIPTION
Tested on Web, IOS , and Android

Redirection to the login page with a token is not presented or no token presented.
It was done by someone before but seems not to be working suddenly.

<img width="766" height="620" alt="image" src="https://github.com/user-attachments/assets/33bfb061-bb4b-4746-94db-054c48039644" />


Therefore, I fixed this by simply passing the navigationRef to the <NavigationContainer> in guard_app/App.tsx

<img width="451" height="92" alt="image" src="https://github.com/user-attachments/assets/31ce39d2-6011-478f-a433-48c01778802f" />
<img width="358" height="813" alt="image" src="https://github.com/user-attachments/assets/2603759e-aaa2-4ea7-b8d4-5de58651fa32" />

