### PR TITLE
Move Notification Test

### DIFF
--- a/guard_app/src/screen/HomeScreen.tsx
+++ b/guard_app/src/screen/HomeScreen.tsx
@@ -22,7 +22,6 @@ import http from '../lib/http';
 import { RootStackParamList } from '../navigation/AppNavigator';
 import { useAppTheme } from '../theme';
 import { AppColors } from '../theme/colors';
-import { showLocalNotification } from '../utils/notificationHelpers';
 
 type Nav = NativeStackNavigationProp<RootStackParamList>;
 
@@ -321,16 +320,6 @@ export default function HomeScreen() {
               <Text style={styles.emptyText}>{t('home.noUpcoming')}</Text>
             )}
           </View>
-
-          <View style={{ justifyContent: 'center', padding: 20 }}>
-            <Button
-              title={t('homeExtras.testNotif')}
-              onPress={async () => {
-                await showLocalNotification(t('homeExtras.notifTitle'), t('homeExtras.notifBody'));
-              }}
-            />
-          </View>
-
           <View style={styles.spacer} />
         </View>
       </ScrollView>

--- a/guard_app/src/screen/SettingsScreen.tsx
+++ b/guard_app/src/screen/SettingsScreen.tsx
@@ -286,10 +286,10 @@ export default function SettingsScreen() {
           />
           <Row
             icon={<Ionicons name="notifications-outline" size={18} color={colors.primary} />}
-            label={t("homeExtras.testNotif")}
+            label={t('homeExtras.testNotif')}
             onPress={async () => {
-                            await showLocalNotification(t('homeExtras.notifTitle'), t('homeExtras.notifBody'));
-                          }}
+              await showLocalNotification(t('homeExtras.notifTitle'), t('homeExtras.notifBody'));
+            }}
             colors={colors}
           />
         </View>

--- a/guard_app/src/screen/SettingsScreen.tsx
+++ b/guard_app/src/screen/SettingsScreen.tsx
@@ -25,6 +25,7 @@ import { LocalStorage } from '../lib/localStorage';
 import { RootStackParamList } from '../navigation/AppNavigator';
 import { useAppTheme } from '../theme';
 import { AppColors } from '../theme/colors';
+import { showLocalNotification } from '../utils/notificationHelpers';
 
 type Nav = NativeStackNavigationProp<RootStackParamList>;
 
@@ -281,6 +282,14 @@ export default function SettingsScreen() {
             icon={<Ionicons name="qr-code-outline" size={18} color={colors.primary} />}
             label="QR Code Scanner"
             onPress={() => navigation2.navigate('QRScanner')}
+            colors={colors}
+          />
+          <Row
+            icon={<Ionicons name="notifications-outline" size={18} color={colors.primary} />}
+            label={t("homeExtras.testNotif")}
+            onPress={async () => {
+                            await showLocalNotification(t('homeExtras.notifTitle'), t('homeExtras.notifBody'));
+                          }}
             colors={colors}
           />
         </View>


### PR DESCRIPTION
## Overview
This pull request moves the Test Notification button from the bottom of the home screen, to the beta card in the settings screen to clean up the app and keep all testing in one place. The notification test has the same functionality as it did on the home screen, successfully sending notifications on press. The button has been restyled to match the rest of the settings screen.
## Screenshots
<img width="1080" height="2142" alt="The notification button in the settings screen." src="https://github.com/user-attachments/assets/456d7d05-4656-4abc-bf2c-238745934584" />
<img width="1080" height="333" alt="The sample notifications generated by the test." src="https://github.com/user-attachments/assets/ea86126f-ee89-4a51-bd09-011ea11f5919" />
<img width="1080" height="2148" alt="Original button removed from home screen" src="https://github.com/user-attachments/assets/ab1382fa-cb46-4099-a802-ff4a5042dd45" />

