### PR TITLE
Fix: Fix to readd payroll button in header

### DIFF
--- a/app-frontend/employer-panel/src/App.js
+++ b/app-frontend/employer-panel/src/App.js
@@ -85,6 +85,7 @@ function AppRoutes() {
         <Route path="/guard-profiles/:guardId" element={<ProtectedLayout><GuardProfilePage /></ProtectedLayout>} />
         <Route path="/company-profile" element={<ProtectedLayout><CompanyProfile /></ProtectedLayout>} />
         <Route path="/email-settings" element={<ProtectedLayout><EmailSettings /></ProtectedLayout>} />
+        <Route path="/payroll" element={<ProtectedLayout><Payroll /></ProtectedLayout>} />
       </Routes>
     </>
   );

--- a/app-frontend/employer-panel/src/components/Header.js
+++ b/app-frontend/employer-panel/src/components/Header.js
@@ -73,6 +73,10 @@ export default function Header() {
           Timesheet
         </Link>
 
+        <Link to="/payroll" style={navButtonStyle}>
+          Payroll
+        </Link>
+
         {localStorage.getItem('userRole') === 'admin' && (
           <Link to="/email-settings" style={navButtonStyle}>
             Email


### PR DESCRIPTION
This fix re-adds the Payroll button in the header.

Added code to header.js and app.js which were likely overwritten during a code merge.

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/bd0e890a-3556-4c6e-b206-dc3a2ea39575" />
