### PR TITLE
perf(lists): optimize MessagesScreen and ShiftsScreen rendering

### DIFF
--- a/guard_app/src/components/card/ShiftCard.tsx
+++ b/guard_app/src/components/card/ShiftCard.tsx
@@ -1,9 +1,7 @@
 // component/card/ShiftCard.tsx
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-
-import { useAppTheme } from '../../theme';
 
 import type { ShiftCardItem } from '../../models/Shifts';
 import type { AppColors } from '../../theme/colors';
@@ -17,16 +15,18 @@ type Props = {
   colors: AppColors;
 };
 
-export default function ShiftCard({
+function ShiftCard({
   shift,
   onPress,
   showApply = false,
   onApply,
   applying = false,
+  colors,
 }: Props) {
-  const { colors } = useAppTheme();
   const { t } = useTranslation();
-  const s = getStyles(colors);
+  // Memoize the stylesheet so the object identity stays stable across renders
+  // when the theme hasn't changed — this lets React.memo on the export do its job.
+  const s = useMemo(() => getStyles(colors), [colors]);
 
   const status = 'status' in shift ? shift.status : 'Completed';
 
@@ -90,6 +90,8 @@ export default function ShiftCard({
     </TouchableOpacity>
   );
 }
+
+export default React.memo(ShiftCard);
 
 const getStyles = (colors: AppColors) =>
   StyleSheet.create({

--- a/guard_app/src/components/list/ConversationItem.tsx
+++ b/guard_app/src/components/list/ConversationItem.tsx
@@ -1,0 +1,89 @@
+// component/list/ConversationItem.tsx
+import React, { useCallback, useMemo } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { useAppTheme } from '../../theme';
+
+import type { AppColors } from '../../theme/colors';
+
+export type ConversationItemData = {
+  id: string;
+  name: string;
+  role?: string;
+  lastMessage: string;
+  lastTimestamp: string;
+  unreadCount: number;
+};
+
+type Props = {
+  conversation: ConversationItemData;
+  onPress: (conversation: ConversationItemData) => void;
+};
+
+function formatTime(iso: string) {
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function ConversationItem({ conversation, onPress }: Props) {
+  const { colors } = useAppTheme();
+  const s = useMemo(() => getStyles(colors), [colors]);
+
+  // Wrap so the inner TouchableOpacity gets a stable arg signature without
+  // letting the parent recreate a closure per item.
+  const handlePress = useCallback(() => onPress(conversation), [onPress, conversation]);
+
+  return (
+    <TouchableOpacity style={s.conversationRow} onPress={handlePress}>
+      <View style={s.conversationInfo}>
+        <View style={s.conversationHeader}>
+          <Text style={s.conversationName}>{conversation.name}</Text>
+          <Text style={s.conversationTime}>{formatTime(conversation.lastTimestamp)}</Text>
+        </View>
+        <Text style={s.conversationPreview} numberOfLines={1}>
+          {conversation.lastMessage}
+        </Text>
+      </View>
+      {conversation.unreadCount > 0 && (
+        <View style={s.unreadBadge}>
+          <Text style={s.unreadText}>{conversation.unreadCount}</Text>
+        </View>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+export default React.memo(ConversationItem);
+
+const getStyles = (colors: AppColors) =>
+  StyleSheet.create({
+    conversationRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: colors.card,
+      borderRadius: 12,
+      padding: 12,
+      marginBottom: 10,
+      borderWidth: 1,
+      borderColor: colors.border,
+    },
+    conversationInfo: { flex: 1 },
+    conversationHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: 4,
+    },
+    conversationName: { fontSize: 14, fontWeight: '700', color: colors.text },
+    conversationTime: { fontSize: 11, color: colors.muted },
+    conversationPreview: { fontSize: 12, color: colors.muted },
+    unreadBadge: {
+      minWidth: 20,
+      paddingHorizontal: 6,
+      height: 20,
+      borderRadius: 10,
+      backgroundColor: colors.primary,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    unreadText: { color: colors.white, fontSize: 11, fontWeight: '700' },
+  });

--- a/guard_app/src/components/list/MessageItem.tsx
+++ b/guard_app/src/components/list/MessageItem.tsx
@@ -41,9 +41,7 @@ function MessageItem({ message }: Props) {
           <Text style={message.isMe ? s.msgTimeLight : s.msgTimeDark}>
             {formatTime(message.timestamp)}
           </Text>
-          {message.isMe && message.status && (
-            <Text style={s.msgStatus}>• {message.status}</Text>
-          )}
+          {message.isMe && message.status && <Text style={s.msgStatus}>• {message.status}</Text>}
         </View>
       </View>
     </View>

--- a/guard_app/src/components/list/MessageItem.tsx
+++ b/guard_app/src/components/list/MessageItem.tsx
@@ -1,0 +1,91 @@
+// component/list/MessageItem.tsx
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { useAppTheme } from '../../theme';
+
+import type { AppColors } from '../../theme/colors';
+
+export type MessageItemData = {
+  id: string;
+  from: 'guard' | 'employer';
+  senderName: string;
+  text: string;
+  timestamp: string;
+  status?: 'sending' | 'sent' | 'delivered' | 'read';
+  isMe: boolean;
+};
+
+type Props = {
+  message: MessageItemData;
+};
+
+function formatTime(iso: string) {
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function MessageItem({ message }: Props) {
+  const { colors } = useAppTheme();
+  // Memoize so the stylesheet identity is stable across parent re-renders
+  // when the theme hasn't changed.
+  const s = useMemo(() => getStyles(colors), [colors]);
+
+  return (
+    <View style={[s.messageRow, message.isMe ? s.rowRight : s.rowLeft]}>
+      <View style={[s.bubble, message.isMe ? s.bubbleGuard : s.bubbleEmployer]}>
+        <Text style={s.msgSender}>
+          {message.senderName} • {message.from === 'guard' ? 'Guard' : 'Employer'}
+        </Text>
+        <Text style={message.isMe ? s.msgTextLight : s.msgTextDark}>{message.text}</Text>
+        <View style={s.metaRow}>
+          <Text style={message.isMe ? s.msgTimeLight : s.msgTimeDark}>
+            {formatTime(message.timestamp)}
+          </Text>
+          {message.isMe && message.status && (
+            <Text style={s.msgStatus}>• {message.status}</Text>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export default React.memo(MessageItem);
+
+const getStyles = (colors: AppColors) =>
+  StyleSheet.create({
+    messageRow: {
+      marginBottom: 10,
+      flexDirection: 'row',
+    },
+    rowRight: {
+      justifyContent: 'flex-end',
+    },
+    rowLeft: {
+      justifyContent: 'flex-start',
+    },
+    bubble: {
+      maxWidth: '75%',
+      padding: 12,
+      borderRadius: 16,
+    },
+    bubbleGuard: {
+      alignSelf: 'flex-end',
+      backgroundColor: colors.primary,
+      borderTopRightRadius: 4,
+    },
+    bubbleEmployer: {
+      alignSelf: 'flex-start',
+      backgroundColor: colors.card,
+      borderTopLeftRadius: 4,
+      borderWidth: 1,
+      borderColor: colors.border,
+    },
+    msgSender: { fontSize: 11, color: colors.muted, marginBottom: 4, fontWeight: '600' },
+    msgTextLight: { color: colors.white, fontSize: 15 },
+    msgTextDark: { color: colors.text, fontSize: 15 },
+    metaRow: { flexDirection: 'row', alignItems: 'center', marginTop: 4 },
+    msgTimeLight: { fontSize: 10, color: '#d1d5db' },
+    msgTimeDark: { fontSize: 10, color: colors.muted },
+    msgStatus: { marginLeft: 4, fontSize: 10, color: '#c7d2fe' },
+  });

--- a/guard_app/src/screen/MessagesScreen.tsx
+++ b/guard_app/src/screen/MessagesScreen.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useRoute } from '@react-navigation/native';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   SafeAreaView,
   View,
@@ -24,32 +24,22 @@ import {
   type MessageDto,
   type MessageUser,
 } from '../api/messages';
+import ConversationItemComponent, {
+  type ConversationItemData,
+} from '../components/list/ConversationItem';
+import MessageItem, { type MessageItemData } from '../components/list/MessageItem';
 import { useAppTheme } from '../theme';
 import { AppColors } from '../theme/colors';
 
 import type { RootStackParamList } from '../navigation/AppNavigator';
 import type { RouteProp } from '@react-navigation/native';
 
-type Message = {
-  id: string;
-  from: 'guard' | 'employer';
-  senderName: string;
-  text: string;
-  timestamp: string;
+type Message = MessageItemData & {
   context: 'shift' | 'general';
   shiftTitle?: string;
-  status?: 'sending' | 'sent' | 'delivered' | 'read';
-  isMe: boolean;
 };
 
-type ConversationItem = {
-  id: string;
-  name: string;
-  role?: string;
-  lastMessage: string;
-  lastTimestamp: string;
-  unreadCount: number;
-};
+type ConversationItem = ConversationItemData;
 
 export default function MessagesScreen() {
   const { colors } = useAppTheme();
@@ -253,6 +243,9 @@ export default function MessagesScreen() {
   // server acknowledgment arrives via the existing sendMessage flow.
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isPollingRef = useRef(false);
+  // Used to keep the chat pinned to the newest message whenever the list
+  // content size changes (new sent message, polled-in message, initial load).
+  const messagesListRef = useRef<FlatList<Message>>(null);
 
   useEffect(() => {
     // Always tear down a previous interval before starting a new one so we
@@ -328,9 +321,6 @@ export default function MessagesScreen() {
     };
   }, [activeContext, generalParticipant?.id, shiftParticipant?.id, currentUser?.id]);
 
-  const formatTime = (iso: string) =>
-    new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-
   const sendMessage = async () => {
     if (!input.trim()) return;
     const participant = activeContext === 'shift' ? shiftParticipant : generalParticipant;
@@ -381,51 +371,29 @@ export default function MessagesScreen() {
       Alert.alert('Error', 'Failed to send message');
     }
   };
-  const renderMessage = ({ item }: { item: Message }) => (
-    <View style={[styles.messageRow, item.isMe ? styles.rowRight : styles.rowLeft]}>
-      <View style={[styles.bubble, item.isMe ? styles.bubbleGuard : styles.bubbleEmployer]}>
-        <Text style={styles.msgSender}>
-          {item.senderName} • {item.from === 'guard' ? 'Guard' : 'Employer'}
-        </Text>
-        <Text style={item.isMe ? styles.msgTextLight : styles.msgTextDark}>{item.text}</Text>
-        <View style={styles.metaRow}>
-          <Text style={item.isMe ? styles.msgTimeLight : styles.msgTimeDark}>
-            {formatTime(item.timestamp)}
-          </Text>
-          {item.isMe && item.status && <Text style={styles.msgStatus}>• {item.status}</Text>}
-        </View>
-      </View>
-    </View>
+  // Stable handler so ConversationItem's memo isn't busted on every parent render.
+  const handleConversationPress = useCallback((conversation: ConversationItemData) => {
+    setGeneralParticipant({
+      id: conversation.id,
+      name: conversation.name,
+      role: conversation.role,
+    });
+    setActiveContext('general');
+  }, []);
+
+  const renderMessage = useCallback(
+    ({ item }: { item: Message }) => <MessageItem message={item} />,
+    [],
   );
 
-  const renderConversation = ({ item }: { item: ConversationItem }) => (
-    <TouchableOpacity
-      style={styles.conversationRow}
-      onPress={() => {
-        setGeneralParticipant({
-          id: item.id,
-          name: item.name,
-          role: item.role,
-        });
-        setActiveContext('general');
-      }}
-    >
-      <View style={styles.conversationInfo}>
-        <View style={styles.conversationHeader}>
-          <Text style={styles.conversationName}>{item.name}</Text>
-          <Text style={styles.conversationTime}>{formatTime(item.lastTimestamp)}</Text>
-        </View>
-        <Text style={styles.conversationPreview} numberOfLines={1}>
-          {item.lastMessage}
-        </Text>
-      </View>
-      {item.unreadCount > 0 && (
-        <View style={styles.unreadBadge}>
-          <Text style={styles.unreadText}>{item.unreadCount}</Text>
-        </View>
-      )}
-    </TouchableOpacity>
+  const renderConversation = useCallback(
+    ({ item }: { item: ConversationItem }) => (
+      <ConversationItemComponent conversation={item} onPress={handleConversationPress} />
+    ),
+    [handleConversationPress],
   );
+
+  const keyExtractor = useCallback((item: { id: string }) => item.id, []);
 
   const handleStartConversation = () => {
     const id = newRecipientId.trim();
@@ -521,8 +489,12 @@ export default function MessagesScreen() {
             </View>
             <FlatList
               data={conversations}
-              keyExtractor={(item) => item.id}
+              keyExtractor={keyExtractor}
               renderItem={renderConversation}
+              initialNumToRender={12}
+              maxToRenderPerBatch={8}
+              windowSize={10}
+              removeClippedSubviews={Platform.OS === 'android'}
               contentContainerStyle={[styles.chat, conversations.length === 0 && styles.chatEmpty]}
               ListEmptyComponent={
                 loading ? (
@@ -544,9 +516,18 @@ export default function MessagesScreen() {
           </View>
         ) : (
           <FlatList
+            ref={messagesListRef}
             data={contextMessages}
-            keyExtractor={(item) => item.id}
+            keyExtractor={keyExtractor}
             renderItem={renderMessage}
+            initialNumToRender={15}
+            maxToRenderPerBatch={10}
+            windowSize={11}
+            removeClippedSubviews={Platform.OS === 'android'}
+            // Pin the view to the newest message whenever content grows or shrinks.
+            // Fires on initial mount (jumps to bottom), on every sent message
+            // (optimistic insert grows the list), and on every polled-in message.
+            onContentSizeChange={() => messagesListRef.current?.scrollToEnd({ animated: true })}
             contentContainerStyle={[styles.chat, contextMessages.length === 0 && styles.chatEmpty]}
             ListEmptyComponent={
               loading ? (
@@ -663,36 +644,6 @@ const getStyles = (colors: AppColors) =>
       paddingTop: 12,
       paddingBottom: 4,
     },
-    conversationRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      backgroundColor: colors.card,
-      borderRadius: 12,
-      padding: 12,
-      marginBottom: 10,
-      borderWidth: 1,
-      borderColor: colors.border,
-    },
-    conversationInfo: { flex: 1 },
-    conversationHeader: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      marginBottom: 4,
-    },
-    conversationName: { fontSize: 14, fontWeight: '700', color: colors.text },
-    conversationTime: { fontSize: 11, color: colors.muted },
-    conversationPreview: { fontSize: 12, color: colors.muted },
-    unreadBadge: {
-      minWidth: 20,
-      paddingHorizontal: 6,
-      height: 20,
-      borderRadius: 10,
-      backgroundColor: colors.primary,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    unreadText: { color: colors.white, fontSize: 11, fontWeight: '700' },
     newConversationCard: {
       backgroundColor: colors.card,
       borderRadius: 12,
@@ -722,43 +673,6 @@ const getStyles = (colors: AppColors) =>
       borderRadius: 8,
     },
     newConversationBtnText: { color: colors.white, fontWeight: '700', fontSize: 13 },
-
-    messageRow: {
-      marginBottom: 10,
-      flexDirection: 'row',
-    },
-
-    rowRight: {
-      justifyContent: 'flex-end',
-    },
-
-    rowLeft: {
-      justifyContent: 'flex-start',
-    },
-    bubble: {
-      maxWidth: '75%',
-      padding: 12,
-      borderRadius: 16,
-    },
-    bubbleGuard: {
-      alignSelf: 'flex-end',
-      backgroundColor: colors.primary,
-      borderTopRightRadius: 4,
-    },
-    bubbleEmployer: {
-      alignSelf: 'flex-start',
-      backgroundColor: colors.card,
-      borderTopLeftRadius: 4,
-      borderWidth: 1,
-      borderColor: colors.border,
-    },
-    msgSender: { fontSize: 11, color: colors.muted, marginBottom: 4, fontWeight: '600' },
-    msgTextLight: { color: colors.white, fontSize: 15 },
-    msgTextDark: { color: colors.text, fontSize: 15 },
-    metaRow: { flexDirection: 'row', alignItems: 'center', marginTop: 4 },
-    msgTimeLight: { fontSize: 10, color: '#d1d5db' },
-    msgTimeDark: { fontSize: 10, color: colors.muted },
-    msgStatus: { marginLeft: 4, fontSize: 10, color: '#c7d2fe' },
 
     typingRow: {
       flexDirection: 'row',

--- a/guard_app/src/screen/ShiftsScreen.tsx
+++ b/guard_app/src/screen/ShiftsScreen.tsx
@@ -7,6 +7,7 @@ import {
   Alert,
   Dimensions,
   FlatList,
+  Platform,
   RefreshControl,
   StyleSheet,
   Text,
@@ -141,7 +142,7 @@ function AllTab({ navigation }: Props) {
     setRefreshing(false);
   };
 
-  const handleApply = async (shiftId: string) => {
+  const handleApply = useCallback(async (shiftId: string) => {
     try {
       setApplyingId(shiftId);
       await applyToShift(shiftId);
@@ -152,7 +153,7 @@ function AllTab({ navigation }: Props) {
     } finally {
       setApplyingId(null);
     }
-  };
+  }, [fetchData]);
 
   const filtered = rows.filter((r) =>
     `${r.title}${r.company}${r.site}`.toLowerCase().includes(q.toLowerCase()),
@@ -161,6 +162,22 @@ function AllTab({ navigation }: Props) {
   const handleViewRequests = () => {
     navigation.navigate('ShiftRequests');
   };
+
+  const keyExtractor = useCallback((i: AllShift) => i.id, []);
+
+  const renderItem = useCallback(
+    ({ item }: { item: AllShift }) => (
+      <ShiftCard
+        shift={item}
+        onPress={() => setSelectedShift(item)}
+        colors={colors}
+        showApply
+        onApply={() => handleApply(item.id)}
+        applying={applyingId === item.id}
+      />
+    ),
+    [colors, applyingId, handleApply],
+  );
 
   return (
     <View style={s.screen}>
@@ -188,18 +205,13 @@ function AllTab({ navigation }: Props) {
       ) : (
         <FlatList
           data={filtered}
-          keyExtractor={(i) => i.id}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          initialNumToRender={8}
+          maxToRenderPerBatch={6}
+          windowSize={9}
+          removeClippedSubviews={Platform.OS === 'android'}
           showsVerticalScrollIndicator={false}
-          renderItem={({ item }) => (
-            <ShiftCard
-              shift={item}
-              onPress={() => setSelectedShift(item)}
-              colors={colors}
-              showApply
-              onApply={() => handleApply(item.id)}
-              applying={applyingId === item.id}
-            />
-          )}
           refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
           ListEmptyComponent={<Text style={s.emptyText}>{t('shifts.noShifts')}</Text>}
         />
@@ -259,6 +271,15 @@ function AppliedTab({ navigation }: Props) {
     navigation.navigate('ShiftRequests');
   };
 
+  const keyExtractor = useCallback((i: AppliedShift) => i.id, []);
+
+  const renderItem = useCallback(
+    ({ item }: { item: AppliedShift }) => (
+      <ShiftCard shift={item} onPress={() => setSelectedShift(item)} colors={colors} />
+    ),
+    [colors],
+  );
+
   return (
     <View style={s.screen}>
       <TouchableOpacity style={s.requestsButton} onPress={handleViewRequests}>
@@ -285,11 +306,13 @@ function AppliedTab({ navigation }: Props) {
       ) : (
         <FlatList
           data={filtered}
-          keyExtractor={(i) => i.id}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          initialNumToRender={8}
+          maxToRenderPerBatch={6}
+          windowSize={9}
+          removeClippedSubviews={Platform.OS === 'android'}
           showsVerticalScrollIndicator={false}
-          renderItem={({ item }) => (
-            <ShiftCard shift={item} onPress={() => setSelectedShift(item)} colors={colors} />
-          )}
           refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
           ListEmptyComponent={<Text style={s.emptyText}>{t('shifts.noShifts')}</Text>}
         />
@@ -343,6 +366,15 @@ function CompletedTab({ navigation }: Props) {
     navigation.navigate('ShiftRequests');
   };
 
+  const keyExtractor = useCallback((i: CompletedShift) => i.id, []);
+
+  const renderItem = useCallback(
+    ({ item }: { item: CompletedShift }) => (
+      <ShiftCard shift={item} onPress={() => setSelectedShift(item)} colors={colors} />
+    ),
+    [colors],
+  );
+
   return (
     <View style={s.screen}>
       <TouchableOpacity style={s.requestsButton} onPress={handleViewRequests}>
@@ -373,11 +405,13 @@ function CompletedTab({ navigation }: Props) {
       ) : (
         <FlatList
           data={filtered}
-          keyExtractor={(i) => i.id}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          initialNumToRender={8}
+          maxToRenderPerBatch={6}
+          windowSize={9}
+          removeClippedSubviews={Platform.OS === 'android'}
           showsVerticalScrollIndicator={false}
-          renderItem={({ item }) => (
-            <ShiftCard shift={item} onPress={() => setSelectedShift(item)} colors={colors} />
-          )}
           refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
           ListEmptyComponent={<Text style={s.emptyText}>{t('shifts.noCompleted')}</Text>}
         />

--- a/guard_app/src/screen/ShiftsScreen.tsx
+++ b/guard_app/src/screen/ShiftsScreen.tsx
@@ -142,18 +142,21 @@ function AllTab({ navigation }: Props) {
     setRefreshing(false);
   };
 
-  const handleApply = useCallback(async (shiftId: string) => {
-    try {
-      setApplyingId(shiftId);
-      await applyToShift(shiftId);
-      Alert.alert('Success', 'Shift applied successfully');
-      await fetchData();
-    } catch (error: any) {
-      Alert.alert('Apply Failed', error?.response?.data?.message ?? 'Could not apply for shift');
-    } finally {
-      setApplyingId(null);
-    }
-  }, [fetchData]);
+  const handleApply = useCallback(
+    async (shiftId: string) => {
+      try {
+        setApplyingId(shiftId);
+        await applyToShift(shiftId);
+        Alert.alert('Success', 'Shift applied successfully');
+        await fetchData();
+      } catch (error: any) {
+        Alert.alert('Apply Failed', error?.response?.data?.message ?? 'Could not apply for shift');
+      } finally {
+        setApplyingId(null);
+      }
+    },
+    [fetchData],
+  );
 
   const filtered = rows.filter((r) =>
     `${r.title}${r.company}${r.site}`.toLowerCase().includes(q.toLowerCase()),


### PR DESCRIPTION
## Summary

Optimizes list rendering in `MessagesScreen` and `ShiftsScreen` to ensure smooth scrolling (~60 FPS) with large datasets. Fixes a UX issue where new messages weren't auto-scrolled into view.

## Changes

### Task 1 — FlatList best practices
- Verified both screens already use `FlatList` (not `ScrollView.map()`)
- Memoized `renderItem` and `keyExtractor` with `useCallback` across all 5 lists (2 in MessagesScreen, 3 in ShiftsScreen)
- Added optimization props tuned per list:
  - Messages: `initialNumToRender=15`, `windowSize=11`, `maxToRenderPerBatch=10`
  - Conversations: `initialNumToRender=12`, `windowSize=10`, `maxToRenderPerBatch=8`
  - Shift cards: `initialNumToRender=8`, `windowSize=9`, `maxToRenderPerBatch=6`
- `removeClippedSubviews={Platform.OS === 'android'}` — Android-only to avoid known iOS text/focus glitches

### Task 2 — React.memo for list items
- New file `components/list/MessageItem.tsx` — memoized bubble component with its own stylesheet
- New file `components/list/ConversationItem.tsx` — memoized row with stable `onPress(conversation)` signature
- `ShiftCard` wrapped in `React.memo`; stylesheet now memoized via `useMemo` so memo compare stays stable
- Resolved a pre-existing inconsistency in `ShiftCard` (both `useAppTheme()` hook and unused `colors` prop) — now uses the prop only

### Bonus fix — auto-scroll chat
- Added `messagesListRef` and `onContentSizeChange` to the messages FlatList so the view stays pinned to the newest message on send, on poll, and on initial mount

## Files

| File | Action |
|---|---|
| `guard_app/src/components/card/ShiftCard.tsx` | Memoize, useMemo stylesheet, drop duplicate hook |
| `guard_app/src/components/list/MessageItem.tsx` | **New** |
| `guard_app/src/components/list/ConversationItem.tsx` | **New** |
| `guard_app/src/screen/MessagesScreen.tsx` | Stable callbacks, tuning props, auto-scroll ref |
| `guard_app/src/screen/ShiftsScreen.tsx` | Stable callbacks + tuning props on all 3 tabs |

## Verification

- TypeScript: `tsc --noEmit` clean (only pre-existing unrelated error in `ScanResultScreen.tsx`)
- Manually tested on emulator + device: scroll FPS holds at 55–60 during fast scroll
- Visual parity confirmed — no UI changes
- All interactions verified: send message, apply to shift, open shift modal, switch contexts, pull-to-refresh, search filter
- Auto-scroll verified for sent + polled-in messages

<img width="353" height="809" alt="Screenshot 2026-05-13 at 11 45 35 pm" src="https://github.com/user-attachments/assets/c5602ced-8842-47ff-bb27-5cec2ab55c74" />

<img width="353" height="809" alt="Screenshot 2026-05-13 at 11 45 18 pm" src="https://github.com/user-attachments/assets/3f688656-271c-44a4-93c7-70c7f5bed7ce" />
