### PR TITLE
Implement translation for Hindi (hi) - Guard App Shift Request

### DIFF
--- a/guard_app/src/locales/hi.json
+++ b/guard_app/src/locales/hi.json
@@ -134,7 +134,28 @@
     "noShifts": "कोई शिफ्ट नहीं मिली",
     "noCompleted": "कोई पूर्ण शिफ्ट नहीं मिली",
     "accepted": "स्वीकृत",
-    "swapLeaveRequests": "स्वैप और छुट्टी अनुरोध"
+    "approved": "अनुमोदित",
+    "createRequest": "अनुरोध बनाएं",
+    "viewRequests": "स्वैप और छुट्टी अनुरोध",
+    "change": "बदलें",
+    "requestType": "अनुरोध प्रकार",
+    "requestedDate": "अनुरोध की तारीख",
+    "reason": "कारण",
+    "swap": "स्वैप",
+    "leave": "छुट्टी",
+    "selectRequestType": "अनुरोध प्रकार चुनें",
+    "reasonHint": "माफ करें मैं बीमार हूं...",
+    "requestedTime": "अनुरोधित समय",
+    "selectDate": "तारीख चुनें",
+    "selectTime": "समय चुनें",
+    "notFound": "कोई शिफ्ट अनुरोध नहीं मिला",
+    "requestError": "अनुरोध लोड करने में विफल।",
+    "alerts": {
+      "missingTimeHead": "तारीख या समय गुम है",
+      "missingTimeMsg": "वह तारीख और समय दर्ज करें जब आप अपनी शिफ्ट बदलना चाहते हैं।",
+      "invalidDateHead": "अमान्य तारीख",
+      "invalidDateMsg": "चुनी गई तारीख अमान्य है"
+    }
   },
   "timesheet": {
     "checkIn": "चेक इन:",
@@ -167,7 +188,8 @@
     "shiftDetails": "शिफ्ट विवरण",
     "shifts": "शिफ्ट्स",
     "home": "होम",
-    "profile": "प्रोफ़ाइल"
+    "profile": "प्रोफ़ाइल",
+    "shiftRequests": "शिफ्ट बदलाव अनुरोध"
   },
   "docs": {
     "title": "दस्तावेज़ अवलोकन",


### PR DESCRIPTION
Added missing Hindi translations for the Shift Request section in guard_app/src/locales/hi.json.

Changes:
- Added shift request translation keys to shifts section (approved, createRequest, viewRequests, swap, leave, alerts etc.)
- Added shiftRequests key to nav section
- Updated swapLeaveRequests to viewRequests to match latest en.json structure
<img width="1916" height="946" alt="image" src="https://github.com/user-attachments/assets/e52b50df-553b-4252-82fe-622cb8ffe840" />
<img width="1918" height="937" alt="image" src="https://github.com/user-attachments/assets/45e2e726-903d-4bdb-a7f4-0af4ee8ea5bb" />
