### PR TITLE
fix the color from pending to rejected

### DIFF
--- a/guard_app/src/screen/ScanResultScreen.tsx
+++ b/guard_app/src/screen/ScanResultScreen.tsx
@@ -39,7 +39,7 @@ export default function ScanResultScreen() {
           <Text style={[styles.content, { color: colors.text }]}>{formattedData}</Text>
         </View>
         {!isJson && (
-          <Text style={[styles.warning, { color: colors.status.pending }]}>
+          <Text style={[styles.warning, { color: colors.status.rejected }]}>
             Note: The scanned content is not a valid JSON.
           </Text>
         )}


### PR DESCRIPTION
  status: {
    pending: '#F59E0B',
    confirmed: '#22C55E',
    rejected: '#F87171',
  },
  
  colors.status.rejected should be used instead of pending