### PR TITLE
Fix emergency controller lint errors

### DIFF
--- a/app-backend/src/controllers/emergency.controller.js
+++ b/app-backend/src/controllers/emergency.controller.js
@@ -14,7 +14,9 @@ export const triggerSOS = async (req, res) => {
     }
 
     // 🚫 Prevent spam (1 min cooldown)
-    const lastSOS = await Emergency.findOne({ guardId }).sort({ createdAt: -1 });
+    const lastSOS = await Emergency.findOne({ guardId }).sort({
+      createdAt: -1,
+    });
 
     if (lastSOS && Date.now() - new Date(lastSOS.createdAt).getTime() < 60000) {
       return res.status(429).json({
@@ -76,7 +78,7 @@ export const updateSOSStatus = async (req, res) => {
     const sos = await Emergency.findByIdAndUpdate(
       id,
       { status },
-      { new: true }
+      { new: true },
     );
 
     if (!sos) {

--- a/app-backend/src/controllers/emergency.controller.js
+++ b/app-backend/src/controllers/emergency.controller.js
@@ -58,7 +58,7 @@ export const getSOSHistory = async (req, res) => {
       count: data.length,
       data,
     });
-  } catch (error) {
+  } catch {
     res.status(500).json({ message: "Internal server error" });
   }
 };
@@ -87,7 +87,7 @@ export const updateSOSStatus = async (req, res) => {
       message: "Status updated",
       data: sos,
     });
-  } catch (error) {
+  } catch {
     res.status(500).json({ message: "Internal server error" });
   }
 };


### PR DESCRIPTION
## Summary

Fixes two existing `no-unused-vars` ESLint errors in `app-backend/src/controllers/emergency.controller.js`.

## Changes

- Replaced two unused `catch (error)` parameters with `catch`
- Preserved the existing `500` response behaviour
- No emergency API behaviour was changed

## Validation

- `npx eslint src/controllers/emergency.controller.js` passed
- `git diff --check` passed