### PR TITLE
Fix duplicated /api/v1 prefix in GuardProfile guards fetch

### DIFF
--- a/app-frontend/employer-panel/src/pages/GuardProfile.js
+++ b/app-frontend/employer-panel/src/pages/GuardProfile.js
@@ -20,7 +20,7 @@ const allSkills = [
 const availabilityOptions = ['Available', 'Unavailable', 'On Leave'];
 
 // NEW: read API base from env (Vite or CRA) ---------------------------------
-const API_BASE = process.env.REACT_APP_API_BASE_URL || 'http://localhost:5000';
+const API_BASE = process.env.REACT_APP_API_BASE_URL || 'http://localhost:5000/api/v1';
 // NEW
 
 function GuardProfiles({ language }) {
@@ -62,7 +62,7 @@ function GuardProfiles({ language }) {
         setError(''); // NEW
 
         const token = localStorage.getItem('token'); // NEW (if you use JWT)
-        const res = await fetch(`${API_BASE}/api/v1/users/guards`, {
+        const res = await fetch(`${API_BASE}/users/guards`, {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
**Problem**
The Guard Profiles page failed to load with `Cannot GET /api/v1/api/v1/users/guards`. The fetch in GuardProfile.js appended `/api/v1/users/guards` to API_BASE, but REACT_APP_API_BASE_URL already includes the `/api/v1` prefix (consistent with src/lib/http.js), producing a doubled path that matches no backend route.

**Fix**
Two-line change in GuardProfile.js: the fallback base URL now includes `/api/v1` (matching the codebase convention), and the fetch path is now `/users/guards`.

**Testing**
Ran the full stack locally via Docker Compose with seeded data, logged in as the seeded ops employer, and opened the Guard page.

Before: the request went to `/api/v1/api/v1/users/guards` and failed with Cannot GET, so it never reached a backend route.
<img width="1397" height="539" alt="image" src="https://github.com/user-attachments/assets/f732f35f-309a-4dfa-a112-c843a854330e" />

After: the request now goes to http://localhost:5001/api/v1/users/guards and returns 403 Forbidden with {"message":"Insufficient role"}. The 403 is the pre-existing RBAC issue documented in the T1 handover and is being handled separately.

<img width="1429" height="822" alt="image" src="https://github.com/user-attachments/assets/de0d7247-0d9d-4f23-8231-897e59149d43" />


**Notes**
No other pages call this endpoint, so the change is isolated to GuardProfile.js.

