### PR TITLE
Add Guard app environment example and networking setup

### DIFF
--- a/ENVIRONMENT_SETUP.md
+++ b/ENVIRONMENT_SETUP.md
@@ -89,6 +89,25 @@ Both applications now have centralized Axios instances that:
 
 - **Employer Panel**: Uses `REACT_APP_API_BASE_URL`
 
+- **Guard App**: Uses `EXPO_PUBLIC_API_BASE_URL`
+
+### Guard App Environment Variable
+
+The Guard App supports overriding the backend URL using the `EXPO_PUBLIC_API_BASE_URL` environment variable.
+
+Create a `.env` file inside the `guard_app` directory:
+
+```env
+EXPO_PUBLIC_API_BASE_URL=http://YOUR_LAN_IP:5000
+```
+
+**Notes:**
+
+- On a physical phone, use your computer's LAN IP address.
+- On the Android emulator, use `http://10.0.2.2:5000`.
+- Do not include `/api/v1` because the app appends it automatically.
+- See `guard_app/.env.example` for the template.
+
 ### Updated Files
 
 

--- a/guard_app/.env.example
+++ b/guard_app/.env.example
@@ -1,0 +1,10 @@
+# Optional override for the Guard App backend base URL.
+# Do not include /api/v1 because the app adds it automatically.
+#
+# Physical phone on the same Wi-Fi:
+# EXPO_PUBLIC_API_BASE_URL=http://192.168.1.100:5000
+#
+# Android emulator:
+# EXPO_PUBLIC_API_BASE_URL=http://10.0.2.2:5000
+
+EXPO_PUBLIC_API_BASE_URL=http://YOUR_LAN_IP:5000


### PR DESCRIPTION
## Summary
- Added `guard_app/.env.example`
- Documented `EXPO_PUBLIC_API_BASE_URL`
- Added setup notes for physical devices and Android emulator
- Clarified that the base URL should not include `/api/v1`

## Testing
- Verified backend connectivity from the Android emulator
- Confirmed login requests reached the backend successfully
- Verified the Guard app loaded and authenticated successfully