### PR TITLE
feat(admin-panel): scaffold Admin Panel foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This guide explains how to run the SecureShift project locally using Docker and 
 
 - Backend (Node.js + Express)
 - Frontend (React - Employer Panel)
+- Frontend (React - Admin Panel) — currently run separately on port 3001 (not yet part of the Compose stack)
 - Database (MongoDB)
 
 ## Project Structure
@@ -19,6 +20,10 @@ This guide explains how to run the SecureShift project locally using Docker and 
 - app-frontend/
   - employer-panel/
     - Dockerfile
+    - src/
+  - admin-panel/
+    - Dockerfile
+    - .env.example
     - src/
 ```
 
@@ -73,6 +78,19 @@ docker compose up --build
 
 `--build` rebuilds the backend and employer frontend images when needed.
 
+### Admin Panel (run separately)
+
+The Admin Panel is a separate React app and is **not yet part of the Compose stack** (adding a `frontend-admin` Compose service is a planned task). For now, with the backend running, start it directly:
+
+```bash
+cd app-frontend/admin-panel
+cp .env.example .env        # set REACT_APP_API_BASE_URL if the backend is not on localhost:5000
+npm install
+npm start                   # runs on http://localhost:3001 by default
+```
+
+It defaults to port 3001 so it runs alongside the Employer Panel (3000). Log in at `http://localhost:3001/login` with an **admin** account (backend `POST /api/v1/admin/login`); non-admin users are rejected.
+
 ## Verifying the Setup
 
 Once Docker is running:
@@ -80,6 +98,7 @@ Once Docker is running:
 - Backend health: http://localhost:5000/api/v1/health
 - Swagger Docs: http://localhost:5000/api-docs
 - Frontend (Employer Panel): http://localhost:3000
+- Frontend (Admin Panel): http://localhost:3001 (run separately — see "Admin Panel (run separately)" above)
 - MongoDB: available at localhost:27017 for local tools such as MongoDB Compass
 
 The backend health and Swagger URLs above assume the default `BACKEND_HOST_PORT=5000`. If you override the backend host port, substitute that value in the URLs. For example, with `BACKEND_HOST_PORT=5001`, use:

--- a/app-frontend/admin-panel/.env.example
+++ b/app-frontend/admin-panel/.env.example
@@ -1,0 +1,4 @@
+REACT_APP_API_BASE_URL=http://localhost:5000/api/v1
+
+# Dev server port (Admin Panel defaults to 3001 so it can run alongside the Employer Panel on 3000)
+PORT=3001

--- a/app-frontend/admin-panel/.gitignore
+++ b/app-frontend/admin-panel/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+/build
+.env
+.DS_Store
+npm-debug.log*

--- a/app-frontend/admin-panel/CONTRIBUTING.md
+++ b/app-frontend/admin-panel/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing — SecureShift Admin Panel
+
+Foundation is in place (auth, routing, layout, shared API client, reusable components).
+Follow these conventions so we can work in parallel without stepping on each other.
+
+## Branching
+- Base branch: `frontend/admin-panel`.
+- Feature branches: `username/feature/<page-or-topic>` (e.g. `krisha/feature/audit-logs`).
+- One PR per ticket. PRs target `frontend/admin-panel` and need one review before merge.
+
+## Where things go
+- `pages/`      one file per screen (own your ticket's page here)
+- `components/` reusable UI only (DataTable, Modal, SearchFilter, LoadingComponent)
+- `layouts/`    app shell (sidebar/navbar) — don't duplicate
+- `routes/`     route table + ProtectedRoute
+- `service/`    ALL backend calls go through `adminAPI.js` — never call axios directly in a page
+- `hooks/`, `utils/`, `lib/`  shared logic (auth, http)
+
+## How to build a page (standard pattern)
+1. Add your API call(s) to `service/adminAPI.js`.
+2. In your page: `useEffect` → call the service → handle **loading / error / empty** states.
+3. Render lists with `<DataTable/>`, filters with `<SearchFilter/>`, dialogs with `<Modal/>`.
+4. No mock or hardcoded data — use real endpoints (or leave the page as a placeholder if the endpoint is missing, and flag it as a backend dependency).
+
+## Before opening a PR
+- `npm run lint` passes.
+- Page handles loading/error/empty.
+- No secrets committed (`.env` is git-ignored).

--- a/app-frontend/admin-panel/Dockerfile
+++ b/app-frontend/admin-panel/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD ["npm","start"]

--- a/app-frontend/admin-panel/README.md
+++ b/app-frontend/admin-panel/README.md
@@ -1,0 +1,64 @@
+# SecureShift — Admin Panel (Frontend)
+
+Web admin console for SecureShift, built with Create React App (react-scripts 5), React 19,
+react-router v7 and Axios — mirroring the Employer Panel conventions.
+
+## Getting started
+
+```bash
+cd app-frontend/admin-panel
+cp .env.example .env        # set REACT_APP_API_BASE_URL if not localhost:5000
+npm install
+npm start                   # runs on http://localhost:3001 (default; set via cross-env)
+```
+
+Runs on **port 3001 by default** (so it sits alongside the Employer Panel on 3000). Requires the backend running (default `http://localhost:5000/api/v1`). Log in at `/login`
+with an **admin** account (backend `POST /api/v1/admin/login`); non-admins are redirected out.
+
+## Structure
+
+```
+src/
+├─ pages/        AdminLogin, AdminDashboard, Users, UserDetails, GuardVerification,
+│                Shifts, AuditLogs, Messages, SMTPSettings
+├─ components/   AdminSidebar, AdminNavbar, DataTable, Modal, SearchFilter, LoadingComponent
+├─ layouts/      AdminLayout (sidebar + navbar + content outlet)
+├─ routes/       adminRoutes (route table), ProtectedRoute (admin-only guard)
+├─ service/      adminAPI (all admin endpoint calls)
+├─ hooks/        useAdminAuth (login/logout/session)
+├─ utils/        authentication (token/role helpers, isAdmin)
+└─ lib/          http (Axios instance, token attach, 401 handler)
+```
+
+## Sprint 1 status (foundation)
+
+Built: project structure, admin-only auth + protected routing, dashboard nav shell,
+shared API client, and one working data view (**Users** → `GET /admin/users`).
+Remaining pages are placeholders wired into navigation, to be built in Sprint 2.
+
+## Backend admin API inventory (`/api/v1/admin`)
+
+| Area | Endpoint | Status |
+| --- | --- | --- |
+| Auth | `POST /admin/login` | Available |
+| Users | `GET /admin/users`, `GET /admin/users/:id`, `DELETE /admin/users/:id` | Available |
+| Guard verification | `GET /admin/guards/pending`, `PATCH /admin/guards/:id/license/verify`, `PATCH /admin/guards/:id/license/reject` | Available |
+| Shifts | `GET /admin/shifts` | Available |
+| Audit logs | `GET /admin/audit-logs`, `DELETE /admin/audit-logs/purge` | Available |
+| Messages | `GET /admin/messages`, `DELETE /admin/messages/:id` | Available |
+| SMTP config | `GET /admin/smtp-settings`, `PUT /admin/smtp-settings`, `POST /admin/smtp-settings/test` | Available |
+
+## Docker (optional)
+
+Add a service to the root `docker-compose.yml` mirroring `frontend-employer`, e.g.:
+
+```yaml
+  frontend-admin:
+    build: { context: ./app-frontend/admin-panel }
+    container_name: secureshift-frontend-admin
+    ports: ["${ADMIN_FRONTEND_HOST_PORT:-3001}:3000"]
+    environment:
+      REACT_APP_API_BASE_URL: http://localhost:${BACKEND_HOST_PORT:-5000}/api/v1
+    command: npm start
+    networks: [secureshift]
+```

--- a/app-frontend/admin-panel/public/index.html
+++ b/app-frontend/admin-panel/public/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#1F3864" />
+    <meta name="description" content="SecureShift Admin Panel" />
+    <title>SecureShift Admin</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/app-frontend/admin-panel/src/App.js
+++ b/app-frontend/admin-panel/src/App.js
@@ -1,0 +1,16 @@
+import { BrowserRouter } from 'react-router-dom';
+import AppRoutes from './routes/adminRoutes';
+import { attach401Handler } from './lib/http';
+
+// Auto-logout on 401 responses
+attach401Handler(() => {
+  window.location.href = '/login';
+});
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <AppRoutes />
+    </BrowserRouter>
+  );
+}

--- a/app-frontend/admin-panel/src/components/AdminNavbar.jsx
+++ b/app-frontend/admin-panel/src/components/AdminNavbar.jsx
@@ -1,0 +1,27 @@
+import { useNavigate } from 'react-router-dom';
+import useAdminAuth from '../hooks/useAdminAuth';
+
+export default function AdminNavbar() {
+  const navigate = useNavigate();
+  const { logout, role } = useAdminAuth();
+  const onLogout = () => {
+    logout();
+    navigate('/login', { replace: true });
+  };
+  return (
+    <header
+      style={{
+        display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 12,
+        padding: '10px 24px', background: '#fff', borderBottom: '1px solid #e5e7eb',
+      }}
+    >
+      <span style={{ color: '#555' }}>Signed in as {role || 'admin'}</span>
+      <button
+        onClick={onLogout}
+        style={{ padding: '6px 14px', background: '#274b93', color: '#fff', border: 'none', borderRadius: 4, cursor: 'pointer' }}
+      >
+        Log out
+      </button>
+    </header>
+  );
+}

--- a/app-frontend/admin-panel/src/components/AdminSidebar.jsx
+++ b/app-frontend/admin-panel/src/components/AdminSidebar.jsx
@@ -1,0 +1,36 @@
+import { NavLink } from 'react-router-dom';
+
+const items = [
+  ['/dashboard', 'Dashboard'],
+  ['/users', 'Users'],
+  ['/guard-verification', 'Guard Verification'],
+  ['/shifts', 'Shifts'],
+  ['/audit-logs', 'Audit Logs'],
+  ['/messages', 'Messages'],
+  ['/smtp-settings', 'SMTP Settings'],
+];
+
+export default function AdminSidebar() {
+  return (
+    <aside style={{ width: 220, background: '#18284f', color: '#fff', paddingTop: 16 }}>
+      <div style={{ padding: '0 20px 16px', fontWeight: 700, fontSize: 18 }}>SecureShift Admin</div>
+      <nav>
+        {items.map(([to, label]) => (
+          <NavLink
+            key={to}
+            to={to}
+            style={({ isActive }) => ({
+              display: 'block',
+              padding: '10px 20px',
+              color: '#fff',
+              textDecoration: 'none',
+              background: isActive ? '#274b93' : 'transparent',
+            })}
+          >
+            {label}
+          </NavLink>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/app-frontend/admin-panel/src/components/DataTable.jsx
+++ b/app-frontend/admin-panel/src/components/DataTable.jsx
@@ -1,0 +1,27 @@
+export default function DataTable({ columns = [], rows = [], empty = 'No records found' }) {
+  if (!rows.length) return <p style={{ color: '#777' }}>{empty}</p>;
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse', background: '#fff' }}>
+      <thead>
+        <tr>
+          {columns.map((c) => (
+            <th key={c.key} style={{ textAlign: 'left', padding: '10px 12px', borderBottom: '2px solid #e5e7eb', background: '#f3f4f6' }}>
+              {c.header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r, i) => (
+          <tr key={r._id || i}>
+            {columns.map((c) => (
+              <td key={c.key} style={{ padding: '10px 12px', borderBottom: '1px solid #eef0f3' }}>
+                {c.render ? c.render(r) : r[c.key]}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/app-frontend/admin-panel/src/components/LoadingComponent.jsx
+++ b/app-frontend/admin-panel/src/components/LoadingComponent.jsx
@@ -1,0 +1,3 @@
+export default function LoadingComponent({ label = 'Loading\u2026' }) {
+  return <p style={{ color: '#777' }}>{label}</p>;
+}

--- a/app-frontend/admin-panel/src/components/Modal.jsx
+++ b/app-frontend/admin-panel/src/components/Modal.jsx
@@ -1,0 +1,14 @@
+export default function Modal({ open, title, children, onClose }) {
+  if (!open) return null;
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      onClick={onClose}
+    >
+      <div style={{ background: '#fff', padding: 24, borderRadius: 8, minWidth: 360 }} onClick={(e) => e.stopPropagation()}>
+        <h3 style={{ marginTop: 0 }}>{title}</h3>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/app-frontend/admin-panel/src/components/SearchFilter.jsx
+++ b/app-frontend/admin-panel/src/components/SearchFilter.jsx
@@ -1,0 +1,10 @@
+export default function SearchFilter({ value, onChange, placeholder = 'Search\u2026' }) {
+  return (
+    <input
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      style={{ padding: '8px 12px', border: '1px solid #ccc', borderRadius: 4, marginBottom: 16, width: 280 }}
+    />
+  );
+}

--- a/app-frontend/admin-panel/src/hooks/useAdminAuth.js
+++ b/app-frontend/admin-panel/src/hooks/useAdminAuth.js
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+import { adminLogin } from '../service/adminAPI';
+import { setSession, clearSession, isAuthenticated, isAdmin, getRole } from '../utils/authentication';
+
+export default function useAdminAuth() {
+  const login = useCallback(async (email, password) => {
+    const data = await adminLogin(email, password);
+    if (!data?.token) throw new Error('No token returned');
+    setSession(data.token, data.role);
+    return data;
+  }, []);
+
+  const logout = useCallback(() => clearSession(), []);
+
+  return { login, logout, isAuthenticated: isAuthenticated(), isAdmin: isAdmin(), role: getRole() };
+}

--- a/app-frontend/admin-panel/src/index.css
+++ b/app-frontend/admin-panel/src/index.css
@@ -1,0 +1,1 @@
+*{box-sizing:border-box}body{margin:0;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#222}h1{color:#274b93}

--- a/app-frontend/admin-panel/src/index.js
+++ b/app-frontend/admin-panel/src/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/app-frontend/admin-panel/src/layouts/AdminLayout.jsx
+++ b/app-frontend/admin-panel/src/layouts/AdminLayout.jsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router-dom';
+import AdminSidebar from '../components/AdminSidebar';
+import AdminNavbar from '../components/AdminNavbar';
+
+export default function AdminLayout() {
+  return (
+    <div style={{ display: 'flex', minHeight: '100vh' }}>
+      <AdminSidebar />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <AdminNavbar />
+        <main style={{ padding: 24, background: '#f3f4f6', flex: 1 }}>
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/app-frontend/admin-panel/src/lib/http.js
+++ b/app-frontend/admin-panel/src/lib/http.js
@@ -1,0 +1,34 @@
+import axios from 'axios';
+
+// Shared Axios instance. Base URL is configurable via env (no hardcoded prod URLs).
+const http = axios.create({
+  baseURL: process.env.REACT_APP_API_BASE_URL || 'http://localhost:5000/api/v1',
+  timeout: 20000,
+});
+
+// Attach JWT to every request
+http.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) config.headers.Authorization = `Bearer ${token}`;
+  return config;
+});
+
+// Auto-logout on 401 — but only for an EXPIRED SESSION (a token already exists).
+// A 401 from the login attempt itself (no token yet) must NOT redirect, so the
+// login form can show the real error (e.g. "Invalid credentials").
+export function attach401Handler(onUnauthorized) {
+  http.interceptors.response.use(
+    (res) => res,
+    (err) => {
+      const hadSession = !!localStorage.getItem('token');
+      if (err?.response?.status === 401 && hadSession) {
+        localStorage.removeItem('token');
+        localStorage.removeItem('role');
+        if (onUnauthorized) onUnauthorized();
+      }
+      throw err;
+    }
+  );
+}
+
+export default http;

--- a/app-frontend/admin-panel/src/pages/AdminDashboard.jsx
+++ b/app-frontend/admin-panel/src/pages/AdminDashboard.jsx
@@ -1,0 +1,11 @@
+export default function AdminDashboard() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <p>
+        Welcome to the SecureShift Admin Panel. Use the sidebar to manage users, guard verification,
+        shifts, audit logs, messages and SMTP settings.
+      </p>
+    </div>
+  );
+}

--- a/app-frontend/admin-panel/src/pages/AdminLogin.jsx
+++ b/app-frontend/admin-panel/src/pages/AdminLogin.jsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useAdminAuth from '../hooks/useAdminAuth';
+
+const inp = { display: 'block', width: '100%', padding: '8px 10px', margin: '6px 0 14px', border: '1px solid #ccc', borderRadius: 4, boxSizing: 'border-box' };
+const btn = { width: '100%', padding: 10, background: '#274b93', color: '#fff', border: 'none', borderRadius: 4, cursor: 'pointer' };
+
+export default function AdminLogin() {
+  const navigate = useNavigate();
+  const { login } = useAdminAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await login(email.trim(), password);
+      navigate('/dashboard', { replace: true });
+    } catch (err) {
+      setError(err?.response?.data?.message || err.message || 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', minHeight: '100vh', alignItems: 'center', justifyContent: 'center', background: '#f3f4f6' }}>
+      <form onSubmit={onSubmit} style={{ background: '#fff', padding: 32, borderRadius: 8, width: 340, boxShadow: '0 2px 12px rgba(0,0,0,0.08)' }}>
+        <h2 style={{ marginTop: 0, color: '#274b93' }}>SecureShift Admin</h2>
+        {error && <p style={{ color: '#c00' }}>{error}</p>}
+        <label>Email</label>
+        <input value={email} onChange={(e) => setEmail(e.target.value)} type="email" required style={inp} />
+        <label>Password</label>
+        <input value={password} onChange={(e) => setPassword(e.target.value)} type="password" required style={inp} />
+        <button disabled={loading} style={{ ...btn, opacity: loading ? 0.7 : 1 }}>
+          {loading ? 'Signing in\u2026' : 'Sign in'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app-frontend/admin-panel/src/pages/AuditLogs.jsx
+++ b/app-frontend/admin-panel/src/pages/AuditLogs.jsx
@@ -1,0 +1,8 @@
+export default function AuditLogs() {
+  return (
+    <div>
+      <h1>Audit Logs</h1>
+      <p style={{ color: '#777' }}>Planned (Sprint 2). Backend: GET /admin/audit-logs, DELETE /admin/audit-logs/purge.</p>
+    </div>
+  );
+}

--- a/app-frontend/admin-panel/src/pages/GuardVerification.jsx
+++ b/app-frontend/admin-panel/src/pages/GuardVerification.jsx
@@ -1,0 +1,8 @@
+export default function GuardVerification() {
+  return (
+    <div>
+      <h1>Guard Verification</h1>
+      <p style={{ color: '#777' }}>Planned (Sprint 2). Backend: GET /admin/guards/pending, PATCH /admin/guards/:id/license/verify, PATCH /admin/guards/:id/license/reject.</p>
+    </div>
+  );
+}

--- a/app-frontend/admin-panel/src/pages/Messages.jsx
+++ b/app-frontend/admin-panel/src/pages/Messages.jsx
@@ -1,0 +1,8 @@
+export default function Messages() {
+  return (
+    <div>
+      <h1>Messages</h1>
+      <p style={{ color: '#777' }}>Planned (Sprint 2). Backend: GET /admin/messages, DELETE /admin/messages/:id.</p>
+    </div>
+  );
+}

--- a/app-frontend/admin-panel/src/pages/SMTPSettings.jsx
+++ b/app-frontend/admin-panel/src/pages/SMTPSettings.jsx
@@ -1,0 +1,8 @@
+export default function SMTPSettings() {
+  return (
+    <div>
+      <h1>SMTP Settings</h1>
+      <p style={{ color: '#777' }}>Planned (Sprint 2). Backend: GET/PUT /admin/smtp-settings, POST /admin/smtp-settings/test.</p>
+    </div>
+  );
+}

--- a/app-frontend/admin-panel/src/pages/Shifts.jsx
+++ b/app-frontend/admin-panel/src/pages/Shifts.jsx
@@ -1,0 +1,8 @@
+export default function Shifts() {
+  return (
+    <div>
+      <h1>Shifts</h1>
+      <p style={{ color: '#777' }}>Planned (Sprint 2). Backend: GET /admin/shifts.</p>
+    </div>
+  );
+}

--- a/app-frontend/admin-panel/src/pages/UserDetails.jsx
+++ b/app-frontend/admin-panel/src/pages/UserDetails.jsx
@@ -1,0 +1,8 @@
+export default function UserDetails() {
+  return (
+    <div>
+      <h1>User Details</h1>
+      <p style={{ color: '#777' }}>Planned (Sprint 2). Backend: GET /admin/users/:id, DELETE /admin/users/:id.</p>
+    </div>
+  );
+}

--- a/app-frontend/admin-panel/src/pages/Users.jsx
+++ b/app-frontend/admin-panel/src/pages/Users.jsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import { getUsers } from '../service/adminAPI';
+import DataTable from '../components/DataTable';
+import LoadingComponent from '../components/LoadingComponent';
+import SearchFilter from '../components/SearchFilter';
+
+// First working admin data view — end-to-end integration with GET /admin/users.
+export default function Users() {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        const data = await getUsers();
+        const list = Array.isArray(data) ? data : data.users || data.data || [];
+        if (mounted) setUsers(list);
+      } catch (err) {
+        if (mounted) setError(err?.response?.data?.message || 'Failed to load users');
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const filtered = users.filter(
+    (u) => !query || `${u.name} ${u.email} ${u.role}`.toLowerCase().includes(query.toLowerCase())
+  );
+
+  const columns = [
+    { key: 'name', header: 'Name' },
+    { key: 'email', header: 'Email' },
+    { key: 'role', header: 'Role' },
+    { key: 'createdAt', header: 'Joined', render: (r) => (r.createdAt ? new Date(r.createdAt).toLocaleDateString() : '\u2014') },
+  ];
+
+  return (
+    <div>
+      <h1>Users</h1>
+      <SearchFilter value={query} onChange={setQuery} />
+      {loading ? (
+        <LoadingComponent />
+      ) : error ? (
+        <p style={{ color: '#c00' }}>{error}</p>
+      ) : (
+        <DataTable columns={columns} rows={filtered} empty="No users found" />
+      )}
+    </div>
+  );
+}

--- a/app-frontend/admin-panel/src/routes/ProtectedRoute.jsx
+++ b/app-frontend/admin-panel/src/routes/ProtectedRoute.jsx
@@ -1,0 +1,10 @@
+import { Navigate } from 'react-router-dom';
+import { isAuthenticated, isAdmin } from '../utils/authentication';
+
+// Admin-only guard: unauthenticated or non-admin users are redirected to login.
+export default function ProtectedRoute({ children }) {
+  if (!isAuthenticated() || !isAdmin()) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+}

--- a/app-frontend/admin-panel/src/routes/adminRoutes.jsx
+++ b/app-frontend/admin-panel/src/routes/adminRoutes.jsx
@@ -1,0 +1,38 @@
+import { Routes, Route, Navigate } from 'react-router-dom';
+import ProtectedRoute from './ProtectedRoute';
+import AdminLayout from '../layouts/AdminLayout';
+import AdminLogin from '../pages/AdminLogin';
+import AdminDashboard from '../pages/AdminDashboard';
+import Users from '../pages/Users';
+import UserDetails from '../pages/UserDetails';
+import GuardVerification from '../pages/GuardVerification';
+import Shifts from '../pages/Shifts';
+import AuditLogs from '../pages/AuditLogs';
+import Messages from '../pages/Messages';
+import SMTPSettings from '../pages/SMTPSettings';
+
+export default function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/login" element={<AdminLogin />} />
+      <Route
+        element={
+          <ProtectedRoute>
+            <AdminLayout />
+          </ProtectedRoute>
+        }
+      >
+        <Route path="/" element={<Navigate to="/dashboard" replace />} />
+        <Route path="/dashboard" element={<AdminDashboard />} />
+        <Route path="/users" element={<Users />} />
+        <Route path="/users/:id" element={<UserDetails />} />
+        <Route path="/guard-verification" element={<GuardVerification />} />
+        <Route path="/shifts" element={<Shifts />} />
+        <Route path="/audit-logs" element={<AuditLogs />} />
+        <Route path="/messages" element={<Messages />} />
+        <Route path="/smtp-settings" element={<SMTPSettings />} />
+      </Route>
+      <Route path="*" element={<Navigate to="/dashboard" replace />} />
+    </Routes>
+  );
+}

--- a/app-frontend/admin-panel/src/service/adminAPI.js
+++ b/app-frontend/admin-panel/src/service/adminAPI.js
@@ -1,0 +1,28 @@
+import http from '../lib/http';
+
+// ---- Admin API inventory (all under /api/v1/admin) ----
+// Auth
+export const adminLogin = (email, password) =>
+  http.post('/admin/login', { email, password }).then((r) => r.data);
+
+// User management
+export const getUsers = (params) => http.get('/admin/users', { params }).then((r) => r.data);
+export const getUser = (id) => http.get(`/admin/users/${id}`).then((r) => r.data);
+export const deleteUser = (id) => http.delete(`/admin/users/${id}`).then((r) => r.data);
+
+// Guard verification
+export const getPendingGuards = () => http.get('/admin/guards/pending').then((r) => r.data);
+export const verifyGuardLicense = (id, body) =>
+  http.patch(`/admin/guards/${id}/license/verify`, body).then((r) => r.data);
+export const rejectGuardLicense = (id, body) =>
+  http.patch(`/admin/guards/${id}/license/reject`, body).then((r) => r.data);
+
+// Oversight
+export const getShifts = (params) => http.get('/admin/shifts', { params }).then((r) => r.data);
+export const getAuditLogs = (params) => http.get('/admin/audit-logs', { params }).then((r) => r.data);
+export const getMessages = (params) => http.get('/admin/messages', { params }).then((r) => r.data);
+
+// System configuration
+export const getSmtpSettings = () => http.get('/admin/smtp-settings').then((r) => r.data);
+export const updateSmtpSettings = (body) => http.put('/admin/smtp-settings', body).then((r) => r.data);
+export const testSmtpSettings = (body) => http.post('/admin/smtp-settings/test', body).then((r) => r.data);

--- a/app-frontend/admin-panel/src/theme/colors.js
+++ b/app-frontend/admin-panel/src/theme/colors.js
@@ -1,0 +1,17 @@
+// Shared SecureShift palette — aligned with the Guard App (#274289) and Employer Panel (#274b93).
+export const colors = {
+  primary: '#274b93',       // brand blue (buttons, links, active nav)
+  primaryDark: '#18284f',   // sidebar / dark surfaces
+  primaryDeep: '#072261',   // deepest navy accent
+  bg: '#f3f4f6',            // app background
+  card: '#ffffff',
+  text: '#111827',
+  muted: '#6b7280',
+  border: '#e5e7eb',
+  tableHead: '#f3f4f6',
+  success: '#16a34a',
+  warning: '#854f0b',
+  danger: '#b00020',
+  white: '#ffffff',
+};
+export default colors;

--- a/app-frontend/admin-panel/src/utils/authentication.js
+++ b/app-frontend/admin-panel/src/utils/authentication.js
@@ -1,0 +1,35 @@
+import { jwtDecode } from 'jwt-decode';
+
+export const getToken = () => localStorage.getItem('token');
+export const getRole = () => localStorage.getItem('role');
+export const setSession = (token, role) => {
+  localStorage.setItem('token', token);
+  if (role) localStorage.setItem('role', role);
+};
+export const clearSession = () => {
+  localStorage.removeItem('token');
+  localStorage.removeItem('role');
+};
+
+export const isAuthenticated = () => {
+  const token = getToken();
+  if (!token) return false;
+  try {
+    const decoded = jwtDecode(token);
+    return decoded.exp * 1000 > Date.now();
+  } catch {
+    return false;
+  }
+};
+
+// Admin route protection: only admin / super_admin may enter.
+export const isAdmin = () => {
+  const token = getToken();
+  if (!token) return false;
+  try {
+    const role = jwtDecode(token).role || getRole();
+    return role === 'admin' || role === 'super_admin';
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Overview
Establishes the SecureShift Admin Panel as a new, separate frontend app at `app-frontend/admin-panel`, following the approved Admin Panel Frontend Implementation Proposal. This PR delivers the **Sprint 1 foundation** so the team can build feature pages in parallel on a shared, working base.

### Why a separate app?
Admin authentication is a distinct, privileged flow (`POST /api/v1/admin/login`, admin-only), and the Admin and Employer panels are owned and deployed independently. Keeping them separate also avoids exposing admin surfaces to employer users.

## Tech Stack
Mirrors the Employer Panel for consistency:
- React 19 + Create React App (`react-scripts` 5)
- `react-router-dom` v7, Axios, `jwt-decode`
- ESLint + Prettier (aligned with Employer Panel)
- SecureShift brand palette via `src/theme/colors.js` (primary `#274b93`, navy sidebar, neutral greys)

## What's Included (Sprint 1 Foundation)

### Project Structure
Modular layout per the proposal: `pages/`, `components/`, `layouts/`, `routes/`, `service/`, `hooks/`, `utils/`, `lib/`, `theme/`.

### Authentication & Access Control
- `AdminLogin` page → `useAdminAuth` → `POST /api/v1/admin/login` (stores token + role)
- `ProtectedRoute` — admin-only guard; redirects unauthenticated / non-admin users to `/login`
- Session-only 401 handler (does not hijack the login request, so login errors surface correctly)

### Shared Infrastructure
- HTTP client (`lib/http.js`): env-configurable base URL, JWT attach, 401 handling
- API service (`service/adminAPI.js`): single place for every admin endpoint call
- Layout shell: sidebar + top navbar + content outlet
- Routing table with placeholder pages per module
- Reusable components: `DataTable`, `Modal`, `SearchFilter`, `LoadingComponent`

### Working Data View
- Users page → `GET /api/v1/admin/users` with loading / error / empty states and search (real data, no mocks)

### Documentation
- `README.md` — setup, structure, admin API inventory, Docker snippet
- `CONTRIBUTING.md` — branching, folder conventions, "how to build a page" pattern

### Configuration
- Runs on **port 3001** by default (via `cross-env`) so it sits alongside the Employer Panel on 3000

## Backend Endpoints

### Available & Wired
- `POST /admin/login`, `GET /admin/users`

### Available & Stubbed in `adminAPI` (pages pending)
- `GET /admin/users/:id`, `DELETE /admin/users/:id`
- `GET /admin/guards/pending`, `PATCH /admin/guards/:id/license/verify|reject`
- `GET /admin/shifts`, `GET /admin/audit-logs`, `GET /admin/messages`
- `GET|PUT /admin/smtp-settings`, `POST /admin/smtp-settings/test`

## How to Run & Test
```bash
cd app-frontend/admin-panel
cp .env.example .env
npm install
npm start
```
With the backend running, open `/login` and sign in with an admin account. Non-admins are rejected; admins land on the dashboard, and the Users page loads real data.

## Notes for Reviewers
- This is the base branch for the Admin Panel team (`<username>/feature/<page>`).
- `node_modules` is git-ignored; `package-lock.json` is committed for reproducible installs.
- A `frontend-admin` Docker Compose service is a planned follow-up (**AP 011**) — for now the panel runs via `npm start`.


<img width="1512" height="982" alt="Screenshot 2026-07-26 at 2 54 24 pm" src="https://github.com/user-attachments/assets/b73d508c-1c89-4781-a8b9-17e746325e0a" />
<img width="1512" height="982" alt="Screenshot 2026-07-26 at 2 54 19 pm" src="https://github.com/user-attachments/assets/568fdd73-8be6-44c1-bc39-9bc4782cdf78" />
<img width="1512" height="982" alt="Screenshot 2026-07-26 at 2 54 14 pm" src="https://github.com/user-attachments/assets/1f2275ed-26b0-42ac-9f9a-8da96542f695" />
