### PR TITLE
Add CI lint workflow for the Admin Panel (AP-026)

### DIFF
--- a/.github/workflows/admin-panel-lint.yml
+++ b/.github/workflows/admin-panel-lint.yml
@@ -1,0 +1,41 @@
+name: Admin Panel Lint
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'app-frontend/admin-panel/**'
+      - '.github/workflows/admin-panel-lint.yml'
+  push:
+    branches:
+      - '**'          # run on pushes to any branch in your fork
+    paths:
+      - 'app-frontend/admin-panel/**'
+      - '.github/workflows/admin-panel-lint.yml'
+  workflow_dispatch: {} # allow manual runs from the Actions tab
+
+jobs:
+  lint:
+    name: ESLint & Prettier
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app-frontend/admin-panel
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: app-frontend/admin-panel/package-lock.json
+      - name: Install dependencies
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-audit --no-fund
+          fi
+      - name: Run ESLint
+        run: npm run lint
+      - name: Run Prettier check
+        run: npm run format:check

--- a/app-frontend/admin-panel/package-lock.json
+++ b/app-frontend/admin-panel/package-lock.json
@@ -15981,6 +15981,23 @@
         }
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",

--- a/app-frontend/admin-panel/package.json
+++ b/app-frontend/admin-panel/package.json
@@ -21,7 +21,8 @@
     "eject": "react-scripts eject",
     "lint": "eslint \"src/**/*.{js,jsx}\"",
     "lint:fix": "eslint \"src/**/*.{js,jsx}\" --fix",
-    "prettier": "prettier --write \"src/**/*.{js,jsx,json,css,md}\""
+    "prettier": "prettier --write \"src/**/*.{js,jsx,json,css,md}\"",
+    "format:check": "prettier --check \"src/**/*.{js,jsx,json,css,md}\""
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Overview

Admin Panel PRs currently run **no checks** — `lint.yml` is path-scoped to `guard_app/**` and `backend-lint.yml` to `app-backend/**`, so changes under `app-frontend/admin-panel/**` match no workflow (e.g. #436 showed "Checks 0"). This adds a dedicated CI workflow for the admin panel. Closes **AP-026**.

## Changes

- **New `.github/workflows/admin-panel-lint.yml`** — mirrors the guard-app `lint.yml`: runs ESLint + Prettier check on PRs to `main` and on pushes, scoped to `app-frontend/admin-panel/**` (and the workflow file itself), with `working-directory: app-frontend/admin-panel`.
- **Added a `format:check` script** (`prettier --check …`) to `app-frontend/admin-panel/package.json` so CI verifies formatting without modifying files (the existing `prettier` script uses `--write`).

## Why a dedicated file (not extending lint.yml)

Each panel is its own npm project with its own lockfile and scripts, and a job can only have one `working-directory`. A separate file keeps the admin-panel pipeline isolated from the working guard-app job, gives a clearly-named check, and matches the repo's existing split (`backend-lint.yml` vs `lint.yml`).

## Testing

- ✅ `npm run lint` in `app-frontend/admin-panel` — 0 errors (pre-existing `Modal.jsx` a11y warnings only).
- ✅ `npm run format:check` — all files pass.