### PR TITLE
FE 005: Prepare FAQ page + frontend API service (draft, blocked on backend)

### DIFF
--- a/app-frontend/employer-panel/src/App.js
+++ b/app-frontend/employer-panel/src/App.js
@@ -19,6 +19,7 @@ import TaskDetail from './pages/TaskDetail';
 
 import Header from './components/Header';
 import Footer from './components/Footer';
+import Faq from './pages/Faq';
 import PageTitleHandler from './components/PageTitleHandler';
 
 import ProtectedRoute from './routes/ProtectedRoute';
@@ -75,6 +76,7 @@ function AppRoutes({ language, setLanguage }) {
         <Route path="/task-detail" element={<TaskRoute />} />
         <Route path="/privacy-policy" element={<PrivacyPolicy />} />
         <Route path="/terms-and-condition" element={<TermsAndConditions />} />
+<Route path="/faqs" element={<Faq />} />
 
         {/* PROTECTED ROUTES */}
         <Route

--- a/app-frontend/employer-panel/src/pages/Faq.js
+++ b/app-frontend/employer-panel/src/pages/Faq.js
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import api from '../api/api';
+
+// Temporary fallback data - remove once GET /api/v1/faqs is live and verified (FE 005, step 5)
+const fallbackFaqs = [
+  {
+    _id: 'fallback-1',
+    question: 'How do I create a new shift?',
+    answer: 'Go to the Create Shift page from the dashboard and fill in the shift details.',
+    category: 'Shifts',
+    displayOrder: 1,
+  },
+  {
+    _id: 'fallback-2',
+    question: 'How do I reset my password?',
+    answer: 'Use the Forgot password link on the login page to receive a reset email.',
+    category: 'Account',
+    displayOrder: 2,
+  },
+  ];
+
+export default function Faq() {
+  const [faqs, setFaqs] = useState(fallbackFaqs);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+useEffect(() => {
+  let isMounted = true;
+
+          api.get('/faqs')
+  .then((res) => {
+    if (isMounted && Array.isArray(res.data) && res.data.length > 0) {
+      setFaqs(res.data);
+    }
+  })
+  .catch(() => {
+    if (isMounted) {
+      setError('Unable to load latest FAQs, showing default list.');
+    }
+  })
+  .finally(() => {
+    if (isMounted) {
+      setLoading(false);
+    }
+  });
+
+          return () => {
+            isMounted = false;
+          };
+}, []);
+
+const sortedFaqs = [...faqs].sort(
+  (a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0)
+  );
+
+return (
+  <div style={styles.page}>
+<div style={styles.container}>
+<h1 style={styles.title}>Frequently Asked Questions</h1>
+  {loading && <p style={styles.paragraph}>Loading FAQs...</p>}
+   {error && <p style={styles.paragraph}>{error}</p>}
+    {sortedFaqs.map((faq) => (
+      <div key={faq._id} style={styles.faqItem}>
+      <h2 style={styles.heading}>{faq.question}</h2>
+    <p style={styles.paragraph}>{faq.answer}</p>
+      </div>
+    ))}
+   </div>
+     </div>
+   );
+  }
+
+const styles = {
+  page: { padding: '40px 20px' },
+  container: { maxWidth: '800px', margin: '0 auto' },
+  title: { fontSize: '28px', marginBottom: '20px' },
+  heading: { fontSize: '18px', marginTop: '20px' },
+  paragraph: { fontSize: '15px', lineHeight: 1.6 },
+  faqItem: { marginBottom: '16px' },
+};
+  

--- a/app-frontend/employer-panel/src/pages/Faq.js
+++ b/app-frontend/employer-panel/src/pages/Faq.js
@@ -17,58 +17,67 @@ const fallbackFaqs = [
     category: 'Account',
     displayOrder: 2,
   },
-  ];
+];
 
 export default function Faq() {
   const [faqs, setFaqs] = useState(fallbackFaqs);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [usedFallback, setUsedFallback] = useState(true);
 
-useEffect(() => {
-  let isMounted = true;
+  useEffect(() => {
+    let isMounted = true;
 
-          api.get('/faqs')
-  .then((res) => {
-    if (isMounted && Array.isArray(res.data) && res.data.length > 0) {
-      setFaqs(res.data);
-    }
-  })
-  .catch(() => {
-    if (isMounted) {
-      setError('Unable to load latest FAQs, showing default list.');
-    }
-  })
-  .finally(() => {
-    if (isMounted) {
-      setLoading(false);
-    }
-  });
+    api.get('/faqs')
+      .then((res) => {
+        // BE 022 contract: a successful response is always an array (possibly
+        // empty when there are no active FAQs). Only treat it as "no data"
+        // if it's not an array - an empty array is a valid, real result and
+        // should replace the fallback list instead of being ignored.
+        if (isMounted && Array.isArray(res.data)) {
+          setFaqs(res.data);
+          setUsedFallback(false);
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setError('Unable to load latest FAQs, showing default list.');
+        }
+      })
+      .finally(() => {
+        if (isMounted) {
+          setLoading(false);
+        }
+      });
 
-          return () => {
-            isMounted = false;
-          };
-}, []);
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
-const sortedFaqs = [...faqs].sort(
-  (a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0)
+  const sortedFaqs = [...faqs].sort(
+    (a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0)
   );
 
-return (
-  <div style={styles.page}>
-<div style={styles.container}>
-<h1 style={styles.title}>Frequently Asked Questions</h1>
-  {loading && <p style={styles.paragraph}>Loading FAQs...</p>}
-   {error && <p style={styles.paragraph}>{error}</p>}
-    {sortedFaqs.map((faq) => (
-      <div key={faq._id} style={styles.faqItem}>
-      <h2 style={styles.heading}>{faq.question}</h2>
-    <p style={styles.paragraph}>{faq.answer}</p>
+  return (
+    <div style={styles.page}>
+      <div style={styles.container}>
+        <h1 style={styles.title}>Frequently Asked Questions</h1>
+        {loading && <p style={styles.paragraph}>Loading FAQs...</p>}
+        {error && <p style={styles.paragraph}>{error}</p>}
+        {!loading && !error && !usedFallback && sortedFaqs.length === 0 && (
+          <p style={styles.paragraph}>No FAQs are available right now.</p>
+        )}
+        {sortedFaqs.map((faq) => (
+          <div key={faq._id} style={styles.faqItem}>
+            <h2 style={styles.heading}>{faq.question}</h2>
+            <p style={styles.paragraph}>{faq.answer}</p>
+          </div>
+        ))}
       </div>
-    ))}
-   </div>
-     </div>
-   );
-  }
+    </div>
+  );
+}
 
 const styles = {
   page: { padding: '40px 20px' },
@@ -78,4 +87,3 @@ const styles = {
   paragraph: { fontSize: '15px', lineHeight: 1.6 },
   faqItem: { marginBottom: '16px' },
 };
-  

--- a/app-frontend/employer-panel/src/pages/Faq.js
+++ b/app-frontend/employer-panel/src/pages/Faq.js
@@ -1,83 +1,62 @@
 import React, { useEffect, useState } from 'react';
 import api from '../api/api';
 
-// Temporary fallback data - remove once GET /api/v1/faqs is live and verified (FE 005, step 5)
-const fallbackFaqs = [
-  {
-    _id: 'fallback-1',
-    question: 'How do I create a new shift?',
-    answer: 'Go to the Create Shift page from the dashboard and fill in the shift details.',
-    category: 'Shifts',
-    displayOrder: 1,
-  },
-  {
-    _id: 'fallback-2',
-    question: 'How do I reset my password?',
-    answer: 'Use the Forgot password link on the login page to receive a reset email.',
-    category: 'Account',
-    displayOrder: 2,
-  },
-];
-
 export default function Faq() {
-  const [faqs, setFaqs] = useState(fallbackFaqs);
+  const [faqs, setFaqs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [usedFallback, setUsedFallback] = useState(true);
 
-  useEffect(() => {
-    let isMounted = true;
+useEffect(() => {
+  let isMounted = true;
 
-    api.get('/faqs')
-      .then((res) => {
-        // BE 022 contract: a successful response is always an array (possibly
-        // empty when there are no active FAQs). Only treat it as "no data"
-        // if it's not an array - an empty array is a valid, real result and
-        // should replace the fallback list instead of being ignored.
+          api.get('/faqs')
+  .then((res) => {
+    // BE 022 contract: a successful response is always an array (possibly
+        // empty when there are no active FAQs). An empty array is a valid
+        // result and should be displayed as-is.
         if (isMounted && Array.isArray(res.data)) {
           setFaqs(res.data);
-          setUsedFallback(false);
         }
-      })
-      .catch(() => {
-        if (isMounted) {
-          setError('Unable to load latest FAQs, showing default list.');
-        }
-      })
-      .finally(() => {
-        if (isMounted) {
-          setLoading(false);
-        }
-      });
+  })
+  .catch(() => {
+    if (isMounted) {
+      setError('Unable to load FAQs right now. Please try again later.');
+    }
+  })
+  .finally(() => {
+    if (isMounted) {
+      setLoading(false);
+    }
+  });
 
-    return () => {
-      isMounted = false;
-    };
-  }, []);
+          return () => {
+            isMounted = false;
+          };
+}, []);
 
-  const sortedFaqs = [...faqs].sort(
-    (a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0)
+const sortedFaqs = [...faqs].sort(
+  (a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0)
   );
 
-  return (
-    <div style={styles.page}>
-      <div style={styles.container}>
-        <h1 style={styles.title}>Frequently Asked Questions</h1>
-        {loading && <p style={styles.paragraph}>Loading FAQs...</p>}
-        {error && <p style={styles.paragraph}>{error}</p>}
-        {!loading && !error && !usedFallback && sortedFaqs.length === 0 && (
-          <p style={styles.paragraph}>No FAQs are available right now.</p>
-        )}
-        {sortedFaqs.map((faq) => (
-          <div key={faq._id} style={styles.faqItem}>
-            <h2 style={styles.heading}>{faq.question}</h2>
-            <p style={styles.paragraph}>{faq.answer}</p>
-          </div>
-        ))}
+return (
+  <div style={styles.page}>
+<div style={styles.container}>
+<h1 style={styles.title}>Frequently Asked Questions</h1>
+  {loading && <p style={styles.paragraph}>Loading FAQs...</p>}
+   {error && <p style={styles.paragraph}>{error}</p>}
+    {!loading && !error && sortedFaqs.length === 0 && (
+      <p style={styles.paragraph}>No FAQs are available right now.</p>
+     )}
+    {sortedFaqs.map((faq) => (
+      <div key={faq._id} style={styles.faqItem}>
+      <h2 style={styles.heading}>{faq.question}</h2>
+    <p style={styles.paragraph}>{faq.answer}</p>
       </div>
-    </div>
-  );
-}
+    ))}
+   </div>
+     </div>
+   );
+  }
 
 const styles = {
   page: { padding: '40px 20px' },


### PR DESCRIPTION
Part of FE 005 - Connect FAQ Page with Backend API.

What this PR does:
- Adds Faq.js page (pattern follows PrivacyPolicy.js) with temporary hardcoded fallback FAQ data.
- - Calls GET /api/v1/faqs via the shared api.js axios instance; falls back to the hardcoded list if the call fails.
- - Registers a public /faqs route in App.js so the existing Footer link is no longer dead.
Blocked / not done yet (waiting on backend, tracked as a separate dependency ticket):
- Backend endpoint GET /api/v1/faqs does not exist yet. Agreed MVP contract: returns active entries with _id, question, answer, category, displayOrder; public read access unless PO requires auth; stored in MongoDB (not static).
- - Fallback hardcoded data will only be removed once the real endpoint is confirmed working (FE 005 checklist step 5) - please do not merge/remove fallback until then.
This is a draft PR for early visibility/review of the frontend approach - not ready to merge yet.

Backend tracking: the backend endpoint work described above is tracked in BE 022 (agreed contract confirmed by backend lead: GET /api/v1/faqs, public, returns only active entries with _id/question/answer/category/displayOrder, no isActive/createdAt/updatedAt/__v, no {success,data} wrapper, empty array when there are no active FAQs). This frontend PR now handles that empty-array case correctly (see latest commit) instead of always falling back to hardcoded data.