### PR TITLE
Fix guard attendance access authorization

### DIFF
--- a/app-backend/src/controllers/shiftattendance.controller.js
+++ b/app-backend/src/controllers/shiftattendance.controller.js
@@ -51,6 +51,19 @@ export const getAttendanceByUserId = async (req, res) => {
   try {
     const { userId } = req.params;
 
+    const LoggedInUserId = req.user?._id || req.user?.id;
+    const userRole = req.user?.role;
+
+    if (
+      userRole === "guard" &&
+      LoggedInUserId.toString() !== userId.toString()
+    ) {
+      return res.status(403).json({
+        message:
+          "You do not have permission to access these attendance records.",
+      });
+    }
+
     const attendanceRecords = await getAttendanceHistoryForUser(userId);
 
     res.status(200).json({


### PR DESCRIPTION
### Summary
This PR implements guard‑level access control for the attendance endpoint. Guards can now view only their own attendance records. Any attempt to access another guard’s records results in a 403 Forbidden response. Administrator behaviour remains unchanged. Employer access rules are currently undefined and have been documented for follow‑up.

### Testing Evidence
1. Guard self‑access (Allowed – 200 OK)
<img width="1917" height="970" alt="Guard self access (1)" src="https://github.com/user-attachments/assets/21b41d0c-dae3-49fe-975c-c2a3f7128393" />
<img width="1917" height="967" alt="Guard self access (2)" src="https://github.com/user-attachments/assets/54a90385-0cd9-400a-903b-232713b780fd" />

2. Guard cross‑access (Denied – 403 Forbidden)
403 Forbidden
{  "message": "You do not have permission to access these attendance records."}
<img width="1426" height="887" alt="403(1)" src="https://github.com/user-attachments/assets/16f3b3c7-9d82-4b7d-abb2-03a256c5439f" />
<img width="1417" height="905" alt="403(2)" src="https://github.com/user-attachments/assets/1c7673c2-d907-495b-8748-c5dbc59b679f" />

3. Admin access (Allowed – 200 OK)
<img width="1917" height="967" alt="Admin access (Allowed – 200 OK)1" src="https://github.com/user-attachments/assets/94b2f825-86f0-4b81-a803-7b656540c62d" />
<img width="1917" height="971" alt="Admin access (Allowed – 200 OK)2" src="https://github.com/user-attachments/assets/4830b160-4185-4e16-afb9-ff50fe3de1c9" />

4. No attendance records (404 Not Found)
<img width="1920" height="970" alt="Screenshot (11)" src="https://github.com/user-attachments/assets/220b1b45-0668-452e-9455-481341e5e6a8" />
<img width="1920" height="985" alt="No attendance records (404 Not Found)2" src="https://github.com/user-attachments/assets/231a17fc-15df-48c6-9486-172e3167ee79" />

5. Invalid userId format (500 Server Error)
<img width="1920" height="967" alt="Invalid userId format (500 Server Error)" src="https://github.com/user-attachments/assets/524dfe63-1446-4744-88a9-364e3336bbd1" />
<img width="1920" height="979" alt="Invalid userId format (500 Server Error)2" src="https://github.com/user-attachments/assets/0d7e0ee2-d7bf-40c2-803c-ae39837f570f" />
