### PR TITLE
BE 027 – Establish Centralised Backend Environment Validation 

### DIFF
--- a/app-backend/.env.example
+++ b/app-backend/.env.example
@@ -1,26 +1,42 @@
-# Local development only. Do not use these values in production.
-# This template is for running the backend directly outside Docker.
-# Docker Compose supplies backend environment values through ../docker-compose.yml
-# and does not read this file.
+# local dev only - don't use these values in production
+# copy this file to .env and fill in your own values
+# note: docker compose does NOT read this file, it uses docker-compose.yml instead
+#
+# startup validation
+# src/config/env.js checks all of these when the server starts up
+# if something is wrong or missing you'll get one clear error listing all problems
+# secrets like JWT_SECRET and SMTP_PASS are never printed, only the variable names
+# production mode requires a longer JWT_SECRET and rejects the default dev keys
+
 NODE_ENV=development
 PORT=5000
 
-# Persist application audit events to the local auditlogs collection.
+# persist application audit events to the local auditlogs collection
 AUDIT_LOG_ENABLED=true
 
-# MONGO_URI is REQUIRED. The backend will not start without it.
-# Local development example (with Docker MongoDB):
+# database (required)
+# must be a mongodb:// or mongodb+srv:// URI
 MONGO_URI=mongodb://secureshift_app:secureshift_app_password@localhost:27017/secureshift_local?authSource=secureshift_local
 
+# auth (required)
+# JWT_SECRET must be at least 8 chars in dev and 32 chars in production
 JWT_SECRET=local-dev-jwt-secret-change-me
+
+# encryption key (required)
+# must be a base64 string that decodes to exactly 32 bytes (AES-256)
+# generate a new one: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 LICENCE_ENC_KEY=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
 
-# Local seed commands are disabled unless this is explicitly changed to true.
+# seeding (disabled by default)
 SEED_ALLOW_LOCAL=false
-# Set only for a deliberate `npm run seed:reset` invocation.
+# only set this when running npm run seed:reset
 SEED_RESET_CONFIRM=
 
-# Host-run backend using Mailpit from ../docker-compose.yml.
+# email / SMTP
+# host-run backend uses Mailpit from ../docker-compose.yml
+# set EMAIL_ENABLED=false to skip all SMTP checks
+# when EMAIL_ENABLED=true, SMTP_HOST and SMTP_FROM_EMAIL are always required
+# SMTP_USER and SMTP_PASS are only required when SMTP_AUTH_REQUIRED=true
 EMAIL_ENABLED=true
 SMTP_HOST=localhost
 SMTP_PORT=1025
@@ -29,3 +45,12 @@ SMTP_AUTH_REQUIRED=false
 SMTP_USER=
 SMTP_PASS=
 SMTP_FROM_EMAIL=local@example.test
+
+# NSW licence verification (optional)
+# set VERIFICATION_ENABLED=false to skip all NSW API credential checks
+# when VERIFICATION_ENABLED=true all four NSW_* variables below are required
+VERIFICATION_ENABLED=false
+NSW_TOKEN_URL=https://api.example.nsw.gov.au/oauth/token
+NSW_VERIFY_URL=https://api.example.nsw.gov.au/v1/verify
+NSW_API_KEY=
+NSW_API_SECRET=

--- a/app-backend/server.js
+++ b/app-backend/server.js
@@ -1,14 +1,14 @@
 // server.js
 // env.js calls dotenv.config() as a module-level side effect and must be the
 // first import so that process.env is populated before any other module reads it.
-import { validateEnv } from './src/config/env.js';
+import { validateEnv } from "./src/config/env.js";
 
 validateEnv(); // exits immediately with a clear report if config is invalid
 
 // Dynamic imports ensure these modules (some of which read process.env at
 // evaluation time, e.g. crypto.js) are only loaded after validation passes.
-const { default: connectDB } = await import('./src/config/connectDB.js');
-const { default: app } = await import('./src/app.js');
+const { default: connectDB } = await import("./src/config/connectDB.js");
+const { default: app } = await import("./src/app.js");
 
 const PORT = parseInt(process.env.PORT, 10) || 5000;
 

--- a/app-backend/server.js
+++ b/app-backend/server.js
@@ -1,21 +1,28 @@
 // server.js
-import "dotenv/config";
-import connectDB from "./src/config/connectDB.js";
-import app from "./src/app.js";
+// env.js calls dotenv.config() as a module-level side effect and must be the
+// first import so that process.env is populated before any other module reads it.
+import { validateEnv } from './src/config/env.js';
 
-const PORT = process.env.PORT || 3000;
+validateEnv(); // exits immediately with a clear report if config is invalid
+
+// Dynamic imports ensure these modules (some of which read process.env at
+// evaluation time, e.g. crypto.js) are only loaded after validation passes.
+const { default: connectDB } = await import('./src/config/connectDB.js');
+const { default: app } = await import('./src/app.js');
+
+const PORT = parseInt(process.env.PORT, 10) || 5000;
 
 const startServer = async () => {
   try {
     await connectDB();
     app.listen(PORT, "0.0.0.0", () => {
-      console.log(`🚀 Server running on http://localhost:${PORT}`);
-      console.log(`📘 Swagger UI: http://localhost:${PORT}/api-docs`);
+      console.log(`?? Server running on http://localhost:${PORT}`);
+      console.log(`?? Swagger UI: http://localhost:${PORT}/api-docs`);
     });
   } catch (err) {
-    console.error("❌ Failed to start server:", err.message);
+    console.error("? Failed to start server:", err.message);
     process.exit(1);
   }
 };
 
-startServer();
+await startServer();

--- a/app-backend/src/config/env.js
+++ b/app-backend/src/config/env.js
@@ -46,8 +46,10 @@ export function collectErrors(env = process.env) {
   const errors = [];
   const nodeEnv = (env.NODE_ENV ?? "development").trim().toLowerCase();
   const isProduction = nodeEnv === "production";
-  const emailEnabled = (env.EMAIL_ENABLED ?? "false").trim().toLowerCase() === "true";
-  const verificationEnabled = (env.VERIFICATION_ENABLED ?? "false").trim().toLowerCase() === "true";
+  const emailEnabled =
+    (env.EMAIL_ENABLED ?? "false").trim().toLowerCase() === "true";
+  const verificationEnabled =
+    (env.VERIFICATION_ENABLED ?? "false").trim().toLowerCase() === "true";
 
   // helper so we don't repeat the label() call everywhere
   function err(name, message) {
@@ -58,7 +60,10 @@ export function collectErrors(env = process.env) {
   const mongoUri = (env.MONGO_URI ?? "").trim();
   if (!mongoUri) {
     err("MONGO_URI", "required but missing");
-  } else if (!mongoUri.startsWith("mongodb://") && !mongoUri.startsWith("mongodb+srv://")) {
+  } else if (
+    !mongoUri.startsWith("mongodb://") &&
+    !mongoUri.startsWith("mongodb+srv://")
+  ) {
     err("MONGO_URI", 'must start with "mongodb://" or "mongodb+srv://"');
   }
 
@@ -68,7 +73,10 @@ export function collectErrors(env = process.env) {
   if (!jwtSecret) {
     err("JWT_SECRET", "required but missing");
   } else if (jwtSecret.length < minJwtLen) {
-    err("JWT_SECRET", `must be at least ${minJwtLen} characters in ${nodeEnv} mode`);
+    err(
+      "JWT_SECRET",
+      `must be at least ${minJwtLen} characters in ${nodeEnv} mode`,
+    );
   } else if (isProduction && jwtSecret === INSECURE_DEFAULTS.JWT_SECRET) {
     err("JWT_SECRET", "cannot use the default dev value in production");
   }
@@ -86,7 +94,10 @@ export function collectErrors(env = process.env) {
   } else {
     const keyBuf = Buffer.from(licenceKey, "base64");
     if (keyBuf.length !== 32) {
-      err("LICENCE_ENC_KEY", `must decode to exactly 32 bytes, got ${keyBuf.length} bytes`);
+      err(
+        "LICENCE_ENC_KEY",
+        `must decode to exactly 32 bytes, got ${keyBuf.length} bytes`,
+      );
     }
     if (isProduction && licenceKey === INSECURE_DEFAULTS.LICENCE_ENC_KEY) {
       err("LICENCE_ENC_KEY", "cannot use the default dev value in production");
@@ -96,7 +107,10 @@ export function collectErrors(env = process.env) {
   // NODE_ENV - only accept known values so typos don't go unnoticed
   const allowedEnvs = ["development", "test", "staging", "production"];
   if (nodeEnv && !allowedEnvs.includes(nodeEnv)) {
-    err("NODE_ENV", `must be one of: ${allowedEnvs.join(", ")}, got "${nodeEnv}"`);
+    err(
+      "NODE_ENV",
+      `must be one of: ${allowedEnvs.join(", ")}, got "${nodeEnv}"`,
+    );
   }
 
   // SMTP settings - only checked when email is actually enabled
@@ -107,7 +121,10 @@ export function collectErrors(env = process.env) {
 
     const smtpPortStr = (env.SMTP_PORT ?? "1025").trim();
     if (!isValidPort(smtpPortStr)) {
-      err("SMTP_PORT", `must be a number between 1 and 65535, got "${smtpPortStr}"`);
+      err(
+        "SMTP_PORT",
+        `must be a number between 1 and 65535, got "${smtpPortStr}"`,
+      );
     }
 
     const smtpSecure = (env.SMTP_SECURE ?? "false").trim().toLowerCase();
@@ -124,10 +141,16 @@ export function collectErrors(env = process.env) {
     // credentials only required when authentication is enabled
     if (smtpAuth === "true") {
       if (!(env.SMTP_USER ?? "").trim()) {
-        err("SMTP_USER", "required when EMAIL_ENABLED=true and SMTP_AUTH_REQUIRED=true");
+        err(
+          "SMTP_USER",
+          "required when EMAIL_ENABLED=true and SMTP_AUTH_REQUIRED=true",
+        );
       }
       if (!(env.SMTP_PASS ?? "").trim()) {
-        err("SMTP_PASS", "required when EMAIL_ENABLED=true and SMTP_AUTH_REQUIRED=true");
+        err(
+          "SMTP_PASS",
+          "required when EMAIL_ENABLED=true and SMTP_AUTH_REQUIRED=true",
+        );
       }
     }
 
@@ -142,14 +165,20 @@ export function collectErrors(env = process.env) {
     if (!nswTokenUrl) {
       err("NSW_TOKEN_URL", "required when VERIFICATION_ENABLED=true");
     } else if (!isValidHttpUrl(nswTokenUrl)) {
-      err("NSW_TOKEN_URL", `must be a valid http/https URL, got "${nswTokenUrl}"`);
+      err(
+        "NSW_TOKEN_URL",
+        `must be a valid http/https URL, got "${nswTokenUrl}"`,
+      );
     }
 
     const nswVerifyUrl = (env.NSW_VERIFY_URL ?? "").trim();
     if (!nswVerifyUrl) {
       err("NSW_VERIFY_URL", "required when VERIFICATION_ENABLED=true");
     } else if (!isValidHttpUrl(nswVerifyUrl)) {
-      err("NSW_VERIFY_URL", `must be a valid http/https URL, got "${nswVerifyUrl}"`);
+      err(
+        "NSW_VERIFY_URL",
+        `must be a valid http/https URL, got "${nswVerifyUrl}"`,
+      );
     }
 
     if (!(env.NSW_API_KEY ?? "").trim()) {
@@ -168,7 +197,9 @@ export function validateEnv() {
   const errors = collectErrors(process.env);
 
   if (errors.length > 0) {
-    console.error("❌ Environment configuration is invalid. Fix the following before starting:\n");
+    console.error(
+      "❌ Environment configuration is invalid. Fix the following before starting:\n",
+    );
     errors.forEach((e) => console.error(e));
     console.error("\nSee app-backend/.env.example for the required variables.");
     process.exit(1);

--- a/app-backend/src/config/env.js
+++ b/app-backend/src/config/env.js
@@ -1,0 +1,179 @@
+// env.js - checks all environment variables at startup so we get one clear
+// error report instead of random crashes scattered across the codebase
+import dotenv from "dotenv";
+
+// load the .env file before anything else runs
+dotenv.config();
+
+// these variables hold sensitive values - we show the name but never the value in logs
+const SECRETS = new Set([
+  "JWT_SECRET",
+  "SMTP_PASS",
+  "NSW_API_SECRET",
+  "LICENCE_ENC_KEY",
+]);
+
+// default placeholder values that are fine locally but must be changed for production
+const INSECURE_DEFAULTS = {
+  JWT_SECRET: "local-dev-jwt-secret-change-me",
+  LICENCE_ENC_KEY: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+};
+
+// if it's a secret, hide the value in the error message
+function label(name) {
+  return SECRETS.has(name) ? `${name} (value hidden)` : name;
+}
+
+// ports must be whole numbers between 1 and 65535
+function isValidPort(str) {
+  const n = Number(str);
+  return Number.isInteger(n) && n >= 1 && n <= 65535;
+}
+
+// only http/https URLs are accepted for the NSW API endpoints
+function isValidHttpUrl(str) {
+  try {
+    const url = new URL(str);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+// goes through every variable and collects all the problems at once
+// returns an array of error strings (empty array means everything is fine)
+export function collectErrors(env = process.env) {
+  const errors = [];
+  const nodeEnv = (env.NODE_ENV ?? "development").trim().toLowerCase();
+  const isProduction = nodeEnv === "production";
+  const emailEnabled = (env.EMAIL_ENABLED ?? "false").trim().toLowerCase() === "true";
+  const verificationEnabled = (env.VERIFICATION_ENABLED ?? "false").trim().toLowerCase() === "true";
+
+  // helper so we don't repeat the label() call everywhere
+  function err(name, message) {
+    errors.push(`  ${label(name)}: ${message}`);
+  }
+
+  // MONGO_URI - the database connection string, always required
+  const mongoUri = (env.MONGO_URI ?? "").trim();
+  if (!mongoUri) {
+    err("MONGO_URI", "required but missing");
+  } else if (!mongoUri.startsWith("mongodb://") && !mongoUri.startsWith("mongodb+srv://")) {
+    err("MONGO_URI", 'must start with "mongodb://" or "mongodb+srv://"');
+  }
+
+  // JWT_SECRET - used to sign auth tokens, needs to be long enough to be secure
+  const jwtSecret = (env.JWT_SECRET ?? "").trim();
+  const minJwtLen = isProduction ? 32 : 8; // stricter in production
+  if (!jwtSecret) {
+    err("JWT_SECRET", "required but missing");
+  } else if (jwtSecret.length < minJwtLen) {
+    err("JWT_SECRET", `must be at least ${minJwtLen} characters in ${nodeEnv} mode`);
+  } else if (isProduction && jwtSecret === INSECURE_DEFAULTS.JWT_SECRET) {
+    err("JWT_SECRET", "cannot use the default dev value in production");
+  }
+
+  // PORT - optional, defaults to 5000 if not set
+  const portStr = (env.PORT ?? "").trim();
+  if (portStr && !isValidPort(portStr)) {
+    err("PORT", `must be a number between 1 and 65535, got "${portStr}"`);
+  }
+
+  // LICENCE_ENC_KEY - AES-256 encryption key, must be exactly 32 bytes when decoded
+  const licenceKey = (env.LICENCE_ENC_KEY ?? "").trim();
+  if (!licenceKey) {
+    err("LICENCE_ENC_KEY", "required but missing");
+  } else {
+    const keyBuf = Buffer.from(licenceKey, "base64");
+    if (keyBuf.length !== 32) {
+      err("LICENCE_ENC_KEY", `must decode to exactly 32 bytes, got ${keyBuf.length} bytes`);
+    }
+    if (isProduction && licenceKey === INSECURE_DEFAULTS.LICENCE_ENC_KEY) {
+      err("LICENCE_ENC_KEY", "cannot use the default dev value in production");
+    }
+  }
+
+  // NODE_ENV - only accept known values so typos don't go unnoticed
+  const allowedEnvs = ["development", "test", "staging", "production"];
+  if (nodeEnv && !allowedEnvs.includes(nodeEnv)) {
+    err("NODE_ENV", `must be one of: ${allowedEnvs.join(", ")}, got "${nodeEnv}"`);
+  }
+
+  // SMTP settings - only checked when email is actually enabled
+  if (emailEnabled) {
+    if (!(env.SMTP_HOST ?? "").trim()) {
+      err("SMTP_HOST", "required when EMAIL_ENABLED=true");
+    }
+
+    const smtpPortStr = (env.SMTP_PORT ?? "1025").trim();
+    if (!isValidPort(smtpPortStr)) {
+      err("SMTP_PORT", `must be a number between 1 and 65535, got "${smtpPortStr}"`);
+    }
+
+    const smtpSecure = (env.SMTP_SECURE ?? "false").trim().toLowerCase();
+    if (smtpSecure !== "true" && smtpSecure !== "false") {
+      err("SMTP_SECURE", `must be "true" or "false", got "${smtpSecure}"`);
+    }
+
+    // SMTP_AUTH_REQUIRED controls whether SMTP credentials are needed
+    const smtpAuth = (env.SMTP_AUTH_REQUIRED ?? "false").trim().toLowerCase();
+    if (smtpAuth !== "true" && smtpAuth !== "false") {
+      err("SMTP_AUTH_REQUIRED", `must be "true" or "false", got "${smtpAuth}"`);
+    }
+
+    // credentials only required when authentication is enabled
+    if (smtpAuth === "true") {
+      if (!(env.SMTP_USER ?? "").trim()) {
+        err("SMTP_USER", "required when EMAIL_ENABLED=true and SMTP_AUTH_REQUIRED=true");
+      }
+      if (!(env.SMTP_PASS ?? "").trim()) {
+        err("SMTP_PASS", "required when EMAIL_ENABLED=true and SMTP_AUTH_REQUIRED=true");
+      }
+    }
+
+    if (!(env.SMTP_FROM_EMAIL ?? "").trim()) {
+      err("SMTP_FROM_EMAIL", "required when EMAIL_ENABLED=true");
+    }
+  }
+
+  // NSW verification credentials - only checked when verification is enabled
+  if (verificationEnabled) {
+    const nswTokenUrl = (env.NSW_TOKEN_URL ?? "").trim();
+    if (!nswTokenUrl) {
+      err("NSW_TOKEN_URL", "required when VERIFICATION_ENABLED=true");
+    } else if (!isValidHttpUrl(nswTokenUrl)) {
+      err("NSW_TOKEN_URL", `must be a valid http/https URL, got "${nswTokenUrl}"`);
+    }
+
+    const nswVerifyUrl = (env.NSW_VERIFY_URL ?? "").trim();
+    if (!nswVerifyUrl) {
+      err("NSW_VERIFY_URL", "required when VERIFICATION_ENABLED=true");
+    } else if (!isValidHttpUrl(nswVerifyUrl)) {
+      err("NSW_VERIFY_URL", `must be a valid http/https URL, got "${nswVerifyUrl}"`);
+    }
+
+    if (!(env.NSW_API_KEY ?? "").trim()) {
+      err("NSW_API_KEY", "required when VERIFICATION_ENABLED=true");
+    }
+    if (!(env.NSW_API_SECRET ?? "").trim()) {
+      err("NSW_API_SECRET", "required when VERIFICATION_ENABLED=true");
+    }
+  }
+
+  return errors;
+}
+
+// called once in server.js - prints all problems together and exits if anything is wrong
+export function validateEnv() {
+  const errors = collectErrors(process.env);
+
+  if (errors.length > 0) {
+    console.error("❌ Environment configuration is invalid. Fix the following before starting:\n");
+    errors.forEach((e) => console.error(e));
+    console.error("\nSee app-backend/.env.example for the required variables.");
+    process.exit(1);
+  }
+
+  const nodeEnv = (process.env.NODE_ENV ?? "development").trim();
+  console.log(`✅ Environment validated (NODE_ENV=${nodeEnv})`);
+}

--- a/app-backend/tests/env.config.test.js
+++ b/app-backend/tests/env.config.test.js
@@ -1,0 +1,345 @@
+// tests for env.js - we test collectErrors() directly so we don't have to
+// worry about process.exit() being called during the tests
+
+import { collectErrors } from "../src/config/env.js";
+
+// a valid dev config we can spread and override in each test
+const VALID_DEV = {
+  NODE_ENV: "development",
+  PORT: "5000",
+  MONGO_URI: "mongodb://localhost:27017/secureshift_local",
+  JWT_SECRET: "atleasteightchars",
+  LICENCE_ENC_KEY: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=", // 32-byte default key
+  EMAIL_ENABLED: "false",
+  VERIFICATION_ENABLED: "false",
+};
+
+// production needs a longer JWT secret and a non-default encryption key
+const VALID_PROD = {
+  NODE_ENV: "production",
+  PORT: "5000",
+  MONGO_URI: "mongodb+srv://user:pass@cluster.mongodb.net/secureshift",
+  JWT_SECRET: "a-very-long-production-secret-that-is-at-least-32-chars",
+  LICENCE_ENC_KEY: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", // 32 null bytes, different from the dev default
+  EMAIL_ENABLED: "false",
+  VERIFICATION_ENABLED: "false",
+};
+
+describe("valid configurations - should pass with no errors", () => {
+  it("basic dev config works", () => {
+    expect(collectErrors(VALID_DEV)).toEqual([]);
+  });
+
+  it("basic production config works", () => {
+    expect(collectErrors(VALID_PROD)).toEqual([]);
+  });
+
+  it("mongodb+srv:// URI is accepted", () => {
+    const env = { ...VALID_DEV, MONGO_URI: "mongodb+srv://user:pass@cluster.mongodb.net/db" };
+    expect(collectErrors(env)).toEqual([]);
+  });
+
+  it("PORT can be left out and it will just use the default", () => {
+    const { PORT: _port, ...env } = VALID_DEV;
+    expect(collectErrors(env)).toEqual([]);
+  });
+
+  it("email config works when all SMTP fields are filled in", () => {
+    const env = {
+      ...VALID_DEV,
+      EMAIL_ENABLED: "true",
+      SMTP_HOST: "localhost",
+      SMTP_PORT: "1025", // mailpit port for local testing
+      SMTP_SECURE: "false",
+      SMTP_AUTH_REQUIRED: "true",
+      SMTP_USER: "test@example.com",
+      SMTP_PASS: "secret",
+      SMTP_FROM_EMAIL: "noreply@example.com",
+    };
+    expect(collectErrors(env)).toEqual([]);
+  });
+
+  it("NSW verification config works when all fields are filled in", () => {
+    const env = {
+      ...VALID_DEV,
+      VERIFICATION_ENABLED: "true",
+      NSW_TOKEN_URL: "https://api.example.nsw.gov.au/oauth/token",
+      NSW_VERIFY_URL: "https://api.example.nsw.gov.au/v1/verify",
+      NSW_API_KEY: "key123",
+      NSW_API_SECRET: "secret456",
+    };
+    expect(collectErrors(env)).toEqual([]);
+  });
+
+  it("SMTP credentials are not required when email is disabled", () => {
+    const env = {
+      ...VALID_DEV,
+      EMAIL_ENABLED: "false",
+      SMTP_HOST: undefined,
+      SMTP_USER: undefined,
+      SMTP_PASS: undefined,
+      SMTP_FROM_EMAIL: undefined,
+    };
+    expect(collectErrors(env)).toEqual([]);
+  });
+
+  it("NSW credentials are not required when verification is disabled", () => {
+    const env = {
+      ...VALID_DEV,
+      VERIFICATION_ENABLED: "false",
+      NSW_TOKEN_URL: undefined,
+      NSW_VERIFY_URL: undefined,
+      NSW_API_KEY: undefined,
+      NSW_API_SECRET: undefined,
+    };
+    expect(collectErrors(env)).toEqual([]);
+  });
+});
+
+describe("MONGO_URI validation", () => {
+  it("errors when MONGO_URI is missing", () => {
+    const { MONGO_URI: _m, ...env } = VALID_DEV;
+    expect(collectErrors(env).some((e) => e.includes("MONGO_URI"))).toBe(true);
+  });
+
+  it("errors when MONGO_URI uses the wrong scheme (e.g. postgres)", () => {
+    const env = { ...VALID_DEV, MONGO_URI: "postgres://localhost/db" };
+    expect(collectErrors(env).some((e) => e.includes("MONGO_URI"))).toBe(true);
+  });
+
+  it("no error for a valid MONGO_URI", () => {
+    expect(collectErrors(VALID_DEV).some((e) => e.includes("MONGO_URI"))).toBe(false);
+  });
+});
+
+describe("JWT_SECRET validation", () => {
+  it("errors when JWT_SECRET is missing", () => {
+    const { JWT_SECRET: _j, ...env } = VALID_DEV;
+    expect(collectErrors(env).some((e) => e.includes("JWT_SECRET"))).toBe(true);
+  });
+
+  it("errors when JWT_SECRET is too short in dev (under 8 chars)", () => {
+    const env = { ...VALID_DEV, JWT_SECRET: "short" };
+    expect(collectErrors(env).some((e) => e.includes("JWT_SECRET"))).toBe(true);
+  });
+
+  it("errors when JWT_SECRET is too short in production (under 32 chars)", () => {
+    const env = { ...VALID_PROD, JWT_SECRET: "tooshort" };
+    expect(collectErrors(env).some((e) => e.includes("JWT_SECRET"))).toBe(true);
+  });
+
+  it("errors when the default dev JWT_SECRET is used in production", () => {
+    const env = { ...VALID_PROD, JWT_SECRET: "local-dev-jwt-secret-change-me" };
+    expect(collectErrors(env).some((e) => e.includes("JWT_SECRET"))).toBe(true);
+  });
+
+  it("never prints the actual JWT_SECRET value in error messages", () => {
+    const secretValue = "mysupersecretjwt12345678901234567";
+    const env = { ...VALID_PROD, JWT_SECRET: secretValue };
+    collectErrors(env).forEach((e) => expect(e).not.toContain(secretValue));
+  });
+});
+
+describe("PORT validation", () => {
+  it("errors for a non-numeric PORT like 'abc'", () => {
+    const env = { ...VALID_DEV, PORT: "abc" };
+    expect(collectErrors(env).some((e) => e.includes("PORT"))).toBe(true);
+  });
+
+  it("errors for PORT=0 (0 is not a valid port)", () => {
+    const env = { ...VALID_DEV, PORT: "0" };
+    expect(collectErrors(env).some((e) => e.includes("PORT"))).toBe(true);
+  });
+
+  it("errors for PORT=65536 (above the max)", () => {
+    const env = { ...VALID_DEV, PORT: "65536" };
+    expect(collectErrors(env).some((e) => e.includes("PORT"))).toBe(true);
+  });
+
+  it("accepts PORT=65535 (the highest valid port)", () => {
+    const env = { ...VALID_DEV, PORT: "65535" };
+    expect(collectErrors(env).some((e) => e.includes("PORT"))).toBe(false);
+  });
+});
+
+describe("LICENCE_ENC_KEY validation", () => {
+  it("errors when LICENCE_ENC_KEY is missing", () => {
+    const { LICENCE_ENC_KEY: _k, ...env } = VALID_DEV;
+    expect(collectErrors(env).some((e) => e.includes("LICENCE_ENC_KEY"))).toBe(true);
+  });
+
+  it("errors when key decodes to fewer than 32 bytes", () => {
+    const shortKey = Buffer.from("tooshort").toString("base64"); // only 8 bytes
+    const env = { ...VALID_DEV, LICENCE_ENC_KEY: shortKey };
+    expect(collectErrors(env).some((e) => e.includes("LICENCE_ENC_KEY"))).toBe(true);
+  });
+
+  it("errors when key decodes to more than 32 bytes", () => {
+    const longKey = Buffer.from("a".repeat(33)).toString("base64");
+    const env = { ...VALID_DEV, LICENCE_ENC_KEY: longKey };
+    expect(collectErrors(env).some((e) => e.includes("LICENCE_ENC_KEY"))).toBe(true);
+  });
+
+  it("errors when the default dev key is used in production", () => {
+    const env = { ...VALID_PROD, LICENCE_ENC_KEY: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=" };
+    expect(collectErrors(env).some((e) => e.includes("LICENCE_ENC_KEY"))).toBe(true);
+  });
+
+  it("never prints the actual LICENCE_ENC_KEY value in error messages", () => {
+    const shortKey = Buffer.from("a".repeat(16)).toString("base64"); // 16 bytes, too short
+    const env = { ...VALID_DEV, LICENCE_ENC_KEY: shortKey };
+    collectErrors(env).forEach((e) => expect(e).not.toContain(shortKey));
+  });
+});
+
+describe("NODE_ENV validation", () => {
+  it("accepts all the known valid values", () => {
+    ["development", "test", "staging", "production"].forEach((nodeEnv) => {
+      const env = nodeEnv === "production" ? VALID_PROD : { ...VALID_DEV, NODE_ENV: nodeEnv };
+      expect(collectErrors(env).some((e) => e.includes("NODE_ENV"))).toBe(false);
+    });
+  });
+
+  it("errors for a typo or unknown value like 'banana'", () => {
+    const env = { ...VALID_DEV, NODE_ENV: "banana" };
+    expect(collectErrors(env).some((e) => e.includes("NODE_ENV"))).toBe(true);
+  });
+});
+
+describe("SMTP validation (only runs when EMAIL_ENABLED=true)", () => {
+  // base with authentication enabled so SMTP_USER/SMTP_PASS are required
+  const BASE_WITH_EMAIL = {
+    ...VALID_DEV,
+    EMAIL_ENABLED: "true",
+    SMTP_HOST: "localhost",
+    SMTP_PORT: "1025", // mailpit default port for local dev
+    SMTP_SECURE: "false",
+    SMTP_AUTH_REQUIRED: "true",
+    SMTP_USER: "user@example.com",
+    SMTP_PASS: "pass",
+    SMTP_FROM_EMAIL: "from@example.com",
+  };
+
+  it("errors when SMTP_HOST is missing", () => {
+    const { SMTP_HOST: _h, ...env } = BASE_WITH_EMAIL;
+    expect(collectErrors(env).some((e) => e.includes("SMTP_HOST"))).toBe(true);
+  });
+
+  it("errors when SMTP_USER is missing and SMTP_AUTH_REQUIRED=true", () => {
+    const { SMTP_USER: _u, ...env } = BASE_WITH_EMAIL;
+    expect(collectErrors(env).some((e) => e.includes("SMTP_USER"))).toBe(true);
+  });
+
+  it("errors when SMTP_PASS is missing and SMTP_AUTH_REQUIRED=true", () => {
+    const { SMTP_PASS: _p, ...env } = BASE_WITH_EMAIL;
+    expect(collectErrors(env).some((e) => e.includes("SMTP_PASS"))).toBe(true);
+  });
+
+  it("errors when SMTP_FROM_EMAIL is missing", () => {
+    const { SMTP_FROM_EMAIL: _f, ...env } = BASE_WITH_EMAIL;
+    expect(collectErrors(env).some((e) => e.includes("SMTP_FROM_EMAIL"))).toBe(true);
+  });
+
+  it("errors for an out of range SMTP_PORT", () => {
+    const env = { ...BASE_WITH_EMAIL, SMTP_PORT: "99999" };
+    expect(collectErrors(env).some((e) => e.includes("SMTP_PORT"))).toBe(true);
+  });
+
+  it("errors when SMTP_SECURE is set to 'yes' instead of 'true' or 'false'", () => {
+    const env = { ...BASE_WITH_EMAIL, SMTP_SECURE: "yes" };
+    expect(collectErrors(env).some((e) => e.includes("SMTP_SECURE"))).toBe(true);
+  });
+
+  it("errors when SMTP_AUTH_REQUIRED is not 'true' or 'false'", () => {
+    const env = { ...BASE_WITH_EMAIL, SMTP_AUTH_REQUIRED: "yes" };
+    expect(collectErrors(env).some((e) => e.includes("SMTP_AUTH_REQUIRED"))).toBe(true);
+  });
+
+  it("never prints the actual SMTP_PASS value in error messages", () => {
+    const secretPass = "mysecretsmtppassword";
+    const { SMTP_HOST: _h, ...env } = { ...BASE_WITH_EMAIL, SMTP_PASS: secretPass };
+    collectErrors(env).forEach((e) => expect(e).not.toContain(secretPass));
+  });
+
+  it("mailpit config with SMTP_AUTH_REQUIRED=false passes with blank credentials", () => {
+    const env = {
+      ...VALID_DEV,
+      EMAIL_ENABLED: "true",
+      SMTP_HOST: "localhost",
+      SMTP_PORT: "1025",
+      SMTP_SECURE: "false",
+      SMTP_AUTH_REQUIRED: "false",
+      SMTP_USER: "",
+      SMTP_PASS: "",
+      SMTP_FROM_EMAIL: "local@example.test",
+    };
+    expect(collectErrors(env)).toEqual([]);
+  });
+
+  it("mailpit config with auth enabled and credentials present passes", () => {
+    expect(collectErrors(BASE_WITH_EMAIL)).toEqual([]);
+  });
+});
+
+describe("NSW verification validation (only runs when VERIFICATION_ENABLED=true)", () => {
+  const BASE_WITH_VERIFY = {
+    ...VALID_DEV,
+    VERIFICATION_ENABLED: "true",
+    NSW_TOKEN_URL: "https://api.example.nsw.gov.au/oauth/token",
+    NSW_VERIFY_URL: "https://api.example.nsw.gov.au/v1/verify",
+    NSW_API_KEY: "key",
+    NSW_API_SECRET: "secret",
+  };
+
+  it("errors when NSW_TOKEN_URL is missing", () => {
+    const { NSW_TOKEN_URL: _t, ...env } = BASE_WITH_VERIFY;
+    expect(collectErrors(env).some((e) => e.includes("NSW_TOKEN_URL"))).toBe(true);
+  });
+
+  it("errors when NSW_VERIFY_URL is missing", () => {
+    const { NSW_VERIFY_URL: _v, ...env } = BASE_WITH_VERIFY;
+    expect(collectErrors(env).some((e) => e.includes("NSW_VERIFY_URL"))).toBe(true);
+  });
+
+  it("errors when NSW_API_KEY is missing", () => {
+    const { NSW_API_KEY: _k, ...env } = BASE_WITH_VERIFY;
+    expect(collectErrors(env).some((e) => e.includes("NSW_API_KEY"))).toBe(true);
+  });
+
+  it("errors when NSW_API_SECRET is missing", () => {
+    const { NSW_API_SECRET: _s, ...env } = BASE_WITH_VERIFY;
+    expect(collectErrors(env).some((e) => e.includes("NSW_API_SECRET"))).toBe(true);
+  });
+
+  it("errors when NSW_TOKEN_URL is not actually a URL", () => {
+    const env = { ...BASE_WITH_VERIFY, NSW_TOKEN_URL: "not-a-url" };
+    expect(collectErrors(env).some((e) => e.includes("NSW_TOKEN_URL"))).toBe(true);
+  });
+
+  it("errors when NSW_VERIFY_URL uses ftp:// instead of http/https", () => {
+    const env = { ...BASE_WITH_VERIFY, NSW_VERIFY_URL: "ftp://example.com/verify" };
+    expect(collectErrors(env).some((e) => e.includes("NSW_VERIFY_URL"))).toBe(true);
+  });
+
+  it("never prints the actual NSW_API_SECRET value in error messages", () => {
+    const secretVal = "nsw-super-secret-key";
+    const { NSW_TOKEN_URL: _t, ...env } = { ...BASE_WITH_VERIFY, NSW_API_SECRET: secretVal };
+    collectErrors(env).forEach((e) => expect(e).not.toContain(secretVal));
+  });
+});
+
+describe("all errors at once", () => {
+  it("returns all problems in one go instead of stopping at the first one", () => {
+    // leave out several required fields and make sure all of them show up
+    const env = {
+      NODE_ENV: "development",
+      EMAIL_ENABLED: "false",
+      VERIFICATION_ENABLED: "false",
+    };
+    const errors = collectErrors(env);
+    expect(errors.some((e) => e.includes("MONGO_URI"))).toBe(true);
+    expect(errors.some((e) => e.includes("JWT_SECRET"))).toBe(true);
+    expect(errors.some((e) => e.includes("LICENCE_ENC_KEY"))).toBe(true);
+    expect(errors.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       SMTP_SECURE: "false"
       SMTP_AUTH_REQUIRED: "false"
       SMTP_FROM_EMAIL: local@example.test
+      VERIFICATION_ENABLED: "false"
     depends_on:
       mongodb:
         condition: service_healthy


### PR DESCRIPTION
- Added src/config/env.js as the single validation entry point that runs once at startup

- Validates MONGO_URI, JWT_SECRET, PORT, LICENCE_ENC_KEY, SMTP settings and NSW API settings

- Secret values are never printed in error output, only the variable names are shown

- SMTP and NSW credentials are only required when EMAIL_ENABLED or VERIFICATION_ENABLED is set to true

- Production mode enforces a stricter minimum JWT_SECRET length and rejects default development keys

- Updated server.js to run validation before loading the app so invalid config exits cleanly before any services start

- Added 43 unit tests covering valid configs, missing fields, invalid formats, production rules and secret hiding

- Updated .env.example to document all validated variables including the new VERIFICATION_ENABLED and NSW variables

- Added VERICATION_ENABLED=false to docker-compose.yml

<img width="545" height="220" alt="1" src="https://github.com/user-attachments/assets/b5b7ab50-c71c-499f-a6af-1fcfe7add1fa" />


<img width="1083" height="266" alt="2" src="https://github.com/user-attachments/assets/d7644623-1f01-45f8-9588-44dc64407682" />


<img width="580" height="983" alt="3" src="https://github.com/user-attachments/assets/f6ffe745-4ea9-4813-b669-1b6995c41ace" />
