### PR TITLE
GA-010: implement confirmed shift application flow

### DIFF
--- a/guard_app/src/components/modal/ShiftDetailsModal.tsx
+++ b/guard_app/src/components/modal/ShiftDetailsModal.tsx
@@ -18,14 +18,7 @@ type Props = {
   applying?: boolean;
 };
 
-function ShiftDetailsModal({
-  shift,
-  visible,
-  onClose,
-  colors,
-  onApply,
-  applying = false,
-}: Props) {
+function ShiftDetailsModal({ shift, visible, onClose, colors, onApply, applying = false }: Props) {
   const s = getStyles(colors);
   const { t } = useTranslation();
   const [requestVisible, setRequestVisible] = useState<boolean>(false);
@@ -113,16 +106,16 @@ function ShiftDetailsModal({
               </View>
             </View>
             {status === 'Available' && onApply ? (
-  <TouchableOpacity
-    style={[s.applyButton, applying && s.applyButtonDisabled]}
-    onPress={onApply}
-    disabled={applying}
-  >
-    <Text style={s.applyButtonText}>
-      {applying ? 'Applying...' : 'Apply for Shift'}
-    </Text>
-  </TouchableOpacity>
-) : null}
+              <TouchableOpacity
+                style={[s.applyButton, applying && s.applyButtonDisabled]}
+                onPress={onApply}
+                disabled={applying}
+              >
+                <Text style={s.applyButtonText}>
+                  {applying ? 'Applying...' : 'Apply for Shift'}
+                </Text>
+              </TouchableOpacity>
+            ) : null}
             {hasAttendance ? (
               <View style={s.modalRequirements}>
                 <Text style={s.modalRequirementsTitle}>Attendance History</Text>
@@ -267,20 +260,20 @@ const getStyles = (colors: AppColors) =>
       color: colors.text,
     },
     applyButton: {
-  marginTop: 16,
-  backgroundColor: colors.primary,
-  paddingVertical: 14,
-  borderRadius: 10,
-  alignItems: 'center',
-},
+      marginTop: 16,
+      backgroundColor: colors.primary,
+      paddingVertical: 14,
+      borderRadius: 10,
+      alignItems: 'center',
+    },
 
-applyButtonDisabled: {
-  opacity: 0.6,
-},
+    applyButtonDisabled: {
+      opacity: 0.6,
+    },
 
-applyButtonText: {
-  color: colors.white,
-  fontSize: 15,
-  fontWeight: '700',
-},
+    applyButtonText: {
+      color: colors.white,
+      fontSize: 15,
+      fontWeight: '700',
+    },
   });

--- a/guard_app/src/components/modal/ShiftDetailsModal.tsx
+++ b/guard_app/src/components/modal/ShiftDetailsModal.tsx
@@ -14,9 +14,18 @@ type Props = {
   visible: boolean;
   onClose: () => void;
   colors: AppColors;
+  onApply?: () => void;
+  applying?: boolean;
 };
 
-function ShiftDetailsModal({ shift, visible, onClose, colors }: Props) {
+function ShiftDetailsModal({
+  shift,
+  visible,
+  onClose,
+  colors,
+  onApply,
+  applying = false,
+}: Props) {
   const s = getStyles(colors);
   const { t } = useTranslation();
   const [requestVisible, setRequestVisible] = useState<boolean>(false);
@@ -103,6 +112,17 @@ function ShiftDetailsModal({ shift, visible, onClose, colors }: Props) {
                 </View>
               </View>
             </View>
+            {status === 'Available' && onApply ? (
+  <TouchableOpacity
+    style={[s.applyButton, applying && s.applyButtonDisabled]}
+    onPress={onApply}
+    disabled={applying}
+  >
+    <Text style={s.applyButtonText}>
+      {applying ? 'Applying...' : 'Apply for Shift'}
+    </Text>
+  </TouchableOpacity>
+) : null}
             {hasAttendance ? (
               <View style={s.modalRequirements}>
                 <Text style={s.modalRequirementsTitle}>Attendance History</Text>
@@ -246,4 +266,21 @@ const getStyles = (colors: AppColors) =>
       fontSize: 12,
       color: colors.text,
     },
+    applyButton: {
+  marginTop: 16,
+  backgroundColor: colors.primary,
+  paddingVertical: 14,
+  borderRadius: 10,
+  alignItems: 'center',
+},
+
+applyButtonDisabled: {
+  opacity: 0.6,
+},
+
+applyButtonText: {
+  color: colors.white,
+  fontSize: 15,
+  fontWeight: '700',
+},
   });

--- a/guard_app/src/screen/ShiftsScreen.tsx
+++ b/guard_app/src/screen/ShiftsScreen.tsx
@@ -190,71 +190,59 @@ function AllTab({ navigation }: Props) {
     setRefreshing(false);
   };
 
-const submitApplication = async (shiftId: string) => {
-  try {
-    setApplyingId(shiftId);
+  const submitApplication = async (shiftId: string) => {
+    try {
+      setApplyingId(shiftId);
 
-    await applyToShift(shiftId);
+      await applyToShift(shiftId);
 
-    Alert.alert('Success', 'Shift applied successfully');
-    await fetchData();
-  } catch (error: unknown) {
-    const apiError = error as {
-      response?: {
-        data?: {
-          message?: string;
+      Alert.alert('Success', 'Shift applied successfully');
+      await fetchData();
+    } catch (error: unknown) {
+      const apiError = error as {
+        response?: {
+          data?: {
+            message?: string;
+          };
         };
       };
-    };
 
-    const message =
-      apiError.response?.data?.message ?? 'Could not apply for shift';
+      const message = apiError.response?.data?.message ?? 'Could not apply for shift';
 
-    const normalizedMessage = message.toLowerCase();
+      const normalizedMessage = message.toLowerCase();
 
-    if (
-      normalizedMessage.includes('already applied') ||
-      normalizedMessage.includes('duplicate')
-    ) {
-      Alert.alert(
-        'Already Applied',
-        'You have already applied for this shift.',
-      );
-    } else if (
-      normalizedMessage.includes('already taken') ||
-      normalizedMessage.includes('not available') ||
-      normalizedMessage.includes('filled') ||
-      normalizedMessage.includes('assigned')
-    ) {
-      Alert.alert(
-        'Shift Unavailable',
-        'This shift is no longer available.',
-      );
-    } else {
-      Alert.alert('Apply Failed', message);
+      if (
+        normalizedMessage.includes('already applied') ||
+        normalizedMessage.includes('duplicate')
+      ) {
+        Alert.alert('Already Applied', 'You have already applied for this shift.');
+      } else if (
+        normalizedMessage.includes('already taken') ||
+        normalizedMessage.includes('not available') ||
+        normalizedMessage.includes('filled') ||
+        normalizedMessage.includes('assigned')
+      ) {
+        Alert.alert('Shift Unavailable', 'This shift is no longer available.');
+      } else {
+        Alert.alert('Apply Failed', message);
+      }
+    } finally {
+      setApplyingId(null);
     }
-  } finally {
-    setApplyingId(null);
-  }
-};
+  };
 
-const handleApply = (shiftId: string) => {
-  if (Platform.OS === 'web') {
-    const confirmed = window.confirm(
-      'Are you sure you want to apply for this shift?',
-    );
+  const handleApply = (shiftId: string) => {
+    if (Platform.OS === 'web') {
+      const confirmed = window.confirm('Are you sure you want to apply for this shift?');
 
-    if (confirmed) {
-      void submitApplication(shiftId);
+      if (confirmed) {
+        void submitApplication(shiftId);
+      }
+
+      return;
     }
 
-    return;
-  }
-
-  Alert.alert(
-    'Confirm Application',
-    'Are you sure you want to apply for this shift?',
-    [
+    Alert.alert('Confirm Application', 'Are you sure you want to apply for this shift?', [
       {
         text: 'Cancel',
         style: 'cancel',
@@ -263,9 +251,8 @@ const handleApply = (shiftId: string) => {
         text: 'Apply',
         onPress: () => void submitApplication(shiftId),
       },
-    ],
-  );
-};
+    ]);
+  };
   const filtered = rows
     .filter((shift) =>
       `${shift.title} ${shift.company} ${shift.site}`
@@ -439,17 +426,17 @@ const handleApply = (shiftId: string) => {
       )}
 
       <ShiftDetailsModal
-  shift={selectedShift}
-  visible={selectedShift !== null}
-  onClose={() => setSelectedShift(null)}
-  colors={colors}
-  onApply={() => {
-    if (selectedShift) {
-      handleApply(selectedShift.id);
-    }
-  }}
-  applying={selectedShift ? applyingId === selectedShift.id : false}
-/>
+        shift={selectedShift}
+        visible={selectedShift !== null}
+        onClose={() => setSelectedShift(null)}
+        colors={colors}
+        onApply={() => {
+          if (selectedShift) {
+            handleApply(selectedShift.id);
+          }
+        }}
+        applying={selectedShift ? applyingId === selectedShift.id : false}
+      />
     </View>
   );
 }

--- a/guard_app/src/screen/ShiftsScreen.tsx
+++ b/guard_app/src/screen/ShiftsScreen.tsx
@@ -7,6 +7,7 @@ import {
   Alert,
   Dimensions,
   FlatList,
+  Platform,
   RefreshControl,
   ScrollView,
   StyleSheet,
@@ -189,19 +190,82 @@ function AllTab({ navigation }: Props) {
     setRefreshing(false);
   };
 
-  const handleApply = async (shiftId: string) => {
-    try {
-      setApplyingId(shiftId);
-      await applyToShift(shiftId);
-      Alert.alert('Success', 'Shift applied successfully');
-      await fetchData();
-    } catch (error: any) {
-      Alert.alert('Apply Failed', error?.response?.data?.message ?? 'Could not apply for shift');
-    } finally {
-      setApplyingId(null);
-    }
-  };
+const submitApplication = async (shiftId: string) => {
+  try {
+    setApplyingId(shiftId);
 
+    await applyToShift(shiftId);
+
+    Alert.alert('Success', 'Shift applied successfully');
+    await fetchData();
+  } catch (error: unknown) {
+    const apiError = error as {
+      response?: {
+        data?: {
+          message?: string;
+        };
+      };
+    };
+
+    const message =
+      apiError.response?.data?.message ?? 'Could not apply for shift';
+
+    const normalizedMessage = message.toLowerCase();
+
+    if (
+      normalizedMessage.includes('already applied') ||
+      normalizedMessage.includes('duplicate')
+    ) {
+      Alert.alert(
+        'Already Applied',
+        'You have already applied for this shift.',
+      );
+    } else if (
+      normalizedMessage.includes('already taken') ||
+      normalizedMessage.includes('not available') ||
+      normalizedMessage.includes('filled') ||
+      normalizedMessage.includes('assigned')
+    ) {
+      Alert.alert(
+        'Shift Unavailable',
+        'This shift is no longer available.',
+      );
+    } else {
+      Alert.alert('Apply Failed', message);
+    }
+  } finally {
+    setApplyingId(null);
+  }
+};
+
+const handleApply = (shiftId: string) => {
+  if (Platform.OS === 'web') {
+    const confirmed = window.confirm(
+      'Are you sure you want to apply for this shift?',
+    );
+
+    if (confirmed) {
+      void submitApplication(shiftId);
+    }
+
+    return;
+  }
+
+  Alert.alert(
+    'Confirm Application',
+    'Are you sure you want to apply for this shift?',
+    [
+      {
+        text: 'Cancel',
+        style: 'cancel',
+      },
+      {
+        text: 'Apply',
+        onPress: () => void submitApplication(shiftId),
+      },
+    ],
+  );
+};
   const filtered = rows
     .filter((shift) =>
       `${shift.title} ${shift.company} ${shift.site}`
@@ -375,11 +439,17 @@ function AllTab({ navigation }: Props) {
       )}
 
       <ShiftDetailsModal
-        shift={selectedShift}
-        visible={selectedShift !== null}
-        onClose={() => setSelectedShift(null)}
-        colors={colors}
-      />
+  shift={selectedShift}
+  visible={selectedShift !== null}
+  onClose={() => setSelectedShift(null)}
+  colors={colors}
+  onApply={() => {
+    if (selectedShift) {
+      handleApply(selectedShift.id);
+    }
+  }}
+  applying={selectedShift ? applyingId === selectedShift.id : false}
+/>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
Implemented the GA-010 end-to-end shift application flow for the Guard App.

## Changes
- Added a confirmation dialog before submitting a shift application.
- Connected the Apply action to the existing shift application API.
- Added success and failure feedback.
- Added clearer handling for already-applied and unavailable shifts.
- Refreshed shift data after a successful application so the status changes to Pending.
- Added an Apply button inside the Shift Details modal.
- Disabled the Apply button while the request is being processed.
- Prevented repeat application from the UI once the shift becomes Pending.

## Testing
- Created a real open shift from the Employer Panel.
- Confirmed the shift appeared in the Guard App.
- Opened the shift details and verified the Apply button.
- Verified the confirmation dialog appeared.
- Submitted the application successfully.
- Confirmed the shift status changed from Available to Pending.
- Confirmed the application appeared in the Employer Panel.
- Tested the complete flow on the Android emulator.

<img width="494" height="1147" alt="image" src="https://github.com/user-attachments/assets/33d1992d-d1fe-42a6-bc5a-5d4a2c8d0926" />

<img width="475" height="544" alt="image" src="https://github.com/user-attachments/assets/732be8c2-f274-4665-baf1-575a67a194f9" />

<img width="486" height="561" alt="image" src="https://github.com/user-attachments/assets/9ab55391-bfda-4259-8b6e-b4e0a876b149" />

<img width="478" height="311" alt="image" src="https://github.com/user-attachments/assets/35d13cbf-9ed0-4e7a-bf33-08878c6d56f7" />

<img width="940" height="486" alt="image" src="https://github.com/user-attachments/assets/ef02afad-8df6-4ea0-8db5-8d81a694463c" />



