### PR TITLE
docs(backend): document Node.js versions across environments (BE 011)

### DIFF
--- a/app-backend/docs/node-version-documentation.md
+++ b/app-backend/docs/node-version-documentation.md
@@ -1,0 +1,34 @@
+## Node.js Version Reference
+
+_Last updated: 7 Aug 2026 - BE 011_
+
+### Current Node versions across environments
+
+| Environment | Node Version | Source |
+|---|---|---|
+| Local development | `v24.18.0` | Developer machine |
+| GitHub Actions (Backend CI) | `22` | `.github/workflows/backend-lint.yml` |
+| GitHub Actions (Frontend/Guard App CI) | `20` | `.github/workflows/lint.yml`, `admin-panel-lint.yml` |
+| Jenkins | `20` | `devops/jenkins.yaml` |
+| Backend Docker image | `18` | `app-backend/Dockerfile` (`FROM node:18`) |
+| `package.json` `engines` field | `>=18` | `app-backend/package.json` |
+
+### Recommendation
+
+Standardize Backend local development, CI and Docker to **Node 22**, same version used by backend GitHub Actions lint workflow (`backend-lint.yml`). The active LTS release at the moment is Node 22 and adopting this is the closest alignment to production-facing CI checks (lint/tests) than the oldest supported floor.
+
+### Known exception
+
+The backend Docker image (`app-backend/Dockerfile`) is now pinned to **Node 18** (not matching CI (Node 22)). This is drift and not an intentional design choice and should be rectified in a separate ticket -- Dockerfile updates are specifically out of scope for BE 011.
+
+### Justified exceptions
+
+- **Jenkins (Node 20):** Jenkins is a major version behind the backend CI recommendation (22) but matches the frontend/Guard App GitHub Actions workflows (20). There is no documented technical blocker for upgrading to 22, it looks like an unreviewed default rather than an intentional limitation. Here tagged for lead to verify if Jenkins has to be upgraded to 22 to align with CI or stay at 20 to align with frontend pipelines – suggest to raise as a follow up instead of fixing in BE 011.
+
+- **`package.json` engines (`>=18`):** This is a permissive range (allows 18 and above), not a pinned version, therefore technically does not clash with any environment above. But it does not implement the suggested baseline of Node 22. This is tightened to `>=22` and needs lead approval before it is implemented. Per ticket scope. Not applied in this PR.
+
+### Notes
+
+- This PR does not add any additional `.nvmrc` or `engines` value, as this requires lead clearance to implement per ticket limitations.
+- This document should be reviewed again after the Docker Node version is aligned with CI in a follow-up ticket.
+- For the comparison, evidence (workflow files, Dockerfile, package.json) was obtained straight from the `Gopher-Industries/SecureShift` repository on GitHub.

--- a/app-backend/docs/node-version-documentation.md
+++ b/app-backend/docs/node-version-documentation.md
@@ -9,7 +9,7 @@ _Last updated: 7 Aug 2026 - BE 011_
 | Local development | `v24.18.0` | Developer machine |
 | GitHub Actions (Backend CI) | `22` | `.github/workflows/backend-lint.yml` |
 | GitHub Actions (Frontend/Guard App CI) | `20` | `.github/workflows/lint.yml`, `admin-panel-lint.yml` |
-| Jenkins | `20` | `devops/jenkins.yaml` |
+| Jenkins | `NodeJS tool: Node20` | `devops/jenkins.yaml` |
 | Backend Docker image | `18` | `app-backend/Dockerfile` (`FROM node:18`) |
 | `package.json` `engines` field | `>=18` | `app-backend/package.json` |
 

--- a/app-backend/docs/node-version-documentation.md
+++ b/app-backend/docs/node-version-documentation.md
@@ -19,7 +19,7 @@ Standardize Backend local development, CI and Docker to **Node 22**, same versio
 
 ### Known exception
 
-The backend Docker image (`app-backend/Dockerfile`) is now pinned to **Node 18** (not matching CI (Node 22)). This is drift and not an intentional design choice and should be rectified in a separate ticket -- Dockerfile updates are specifically out of scope for BE 011.
+The backend Docker image (`app-backend/Dockerfile`) is pinned to **Node 18** (not matching CI (Node 22)). This is drift rather than an intentional design choice and should be rectified in a separate ticket — Dockerfile updates are specifically out of scope for BE 011.
 
 ### Justified exceptions
 

--- a/app-backend/docs/node-version-documentation.md
+++ b/app-backend/docs/node-version-documentation.md
@@ -15,7 +15,7 @@ _Last updated: 7 Aug 2026 - BE 011_
 
 ### Recommendation
 
-Standardize Backend local development, CI and Docker to **Node 22**, same version used by backend GitHub Actions lint workflow (`backend-lint.yml`). The active LTS release at the moment is Node 22 and adopting this is the closest alignment to production-facing CI checks (lint/tests) than the oldest supported floor.
+Standardize Backend local development, CI, and Docker to **Node 22**, the version used by the backend GitHub Actions lint workflow (`backend-lint.yml`). Node 22 is the active LTS release, and adopting it aligns local/dev tooling with the production-facing CI checks (lint/tests) rather than the minimum supported floor.
 
 ### Known exception
 

--- a/app-backend/docs/node-version-documentation.md
+++ b/app-backend/docs/node-version-documentation.md
@@ -25,7 +25,7 @@ The backend Docker image (`app-backend/Dockerfile`) is now pinned to **Node 18**
 
 - **Jenkins (Node 20):** Jenkins is a major version behind the backend CI recommendation (22) but matches the frontend/Guard App GitHub Actions workflows (20). There is no documented technical blocker for upgrading to 22, it looks like an unreviewed default rather than an intentional limitation. Here tagged for lead to verify if Jenkins has to be upgraded to 22 to align with CI or stay at 20 to align with frontend pipelines – suggest to raise as a follow up instead of fixing in BE 011.
 
-- **`package.json` engines (`>=18`):** This is a permissive range (allows 18 and above), not a pinned version, therefore technically does not clash with any environment above. But it does not implement the suggested baseline of Node 22. This is tightened to `>=22` and needs lead approval before it is implemented. Per ticket scope. Not applied in this PR.
+- **`package.json` engines (`>=18`):** This is a permissive range (allows 18 and above), not a pinned version, therefore technically does not clash with any environment above. But it does not implement the suggested baseline of Node 22. This could be tightened to `>=22`, but it needs lead approval before it is implemented (per ticket scope) and is not applied in this PR.
 
 ### Notes
 


### PR DESCRIPTION
Document current node versions utilized across Backend local development, GitHub Actions CI, Jenkins and the Docker Backend image and document findings in a new reference document.

Results:
- Local dev: v24.18.0 
Backend CI (backend-lint.yml): Node 22
- Frontend/Guard App CI (lint.yml, admin-panel-lint.yml): Node 20 
- Jenkins (devops/jenkins.yaml): Node 20 
- Backend Docker image (app-backend/Dockerfile): Node 18 
- app-backend/package.json engines field: >=18 

Propose standardizing Backend local dev, CI and Docker on Node 22 to be consistent with the existing backend-lint CI pipeline.

Flags the docker image (Node 18) as drift from CI, and Jenkins (Node 20) as a default unapproved, rather than a justifiable exception, to be resolved in follow up tickets, beyond scope here per BE 011 limitations.

This PR did not apply any changes to .nvmrc or engines field; these lead approval before implementation per ticket scope. No modifications to Dockerfile or dependent upgrades provided.

Ticket: BE 011