### PR TITLE
BE 009: Add stable backend tests to GitHub Actions

### DIFF
--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Backend stable tests
+        run: npm run test:ci
+
       - name: ESLint
         run: npm run lint
 

--- a/app-backend/README.md
+++ b/app-backend/README.md
@@ -268,6 +268,18 @@ npm run test
 
 Unit and integration tests are managed via Jest (or Mocha/Chai if used).
 
+### CI tests
+
+Pull requests run the following stable, database-free backend suites:
+
+- `tests/env.config.test.js`
+- `tests/seed.safety.test.js`
+- `src/tests/services/fatigue.service.test.js`
+
+Run the same allowlist locally with `npm run test:ci`. The complete legacy suite is intentionally
+not a required pull request gate while some suites have known database, environment, and ESM
+mocking reliability issues.
+
 ### Test Database Configuration
 Database-connected tests use a dedicated MongoDB database `secureshift_test`.
 1. Create a test environment file:

--- a/app-backend/package.json
+++ b/app-backend/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint \"src/**/*.js\"",
     "lint:fix": "eslint \"src/**/*.js\" --fix",
     "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --runInBand",
+    "test:ci": "npm test -- --runTestsByPath tests/env.config.test.js tests/seed.safety.test.js src/tests/services/fatigue.service.test.js",
     "test:watch": "jest --watch",
     "seed": "node -r dotenv/config src/scripts/seed/index.js",
     "seed:reset": "node -r dotenv/config src/scripts/seed/index.js --reset",


### PR DESCRIPTION
## Summary

- add a focused `test:ci` script for three verified DB-free backend suites
- run the stable test set as a blocking step in the existing backend workflow
- document the included suites and why the complete legacy suite is not yet required

## Included suites

- `tests/env.config.test.js`
- `tests/seed.safety.test.js`
- `src/tests/services/fatigue.service.test.js`

## Verification

- `npm run test:ci` passed three consecutive times under Node 22
- 3 suites passed
- 76 tests passed
- 0 failures
- no external services or database required

## CI evidence

- Successful run: TODO
- Intentional selected-test failure: PR #489 / failed `Backend stable tests` step

Planner: BE 009 – Add Stable Backend Tests to GitHub Actions
Dependency: Ticket 8 – Backend Test Failures report

## Tests
https://github.com/Gopher-Industries/SecureShift/pull/489