### PR TITLE
Make uploaded licence and incident files retrievable and persistent (BE 028)

### DIFF
--- a/app-backend/src/config/multer.js
+++ b/app-backend/src/config/multer.js
@@ -1,14 +1,10 @@
 // config/multer.js
 import multer from "multer";
 import fs from "fs";
-import path from "path";
-// import { fileURLToPath } from "url";
+import { uploadsDir } from "./uploadsDir.js";
 
-// const __filename = fileURLToPath(import.meta.url);
-// const __dirname = path.dirname(__filename);
-
-// ensure uploads dir exists
-const uploadsDir = path.join(process.cwd(), "uploads");
+// ensure uploads dir exists. The path lives in its own module so retrieval
+// resolves files against the same directory uploads are written to.
 if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir, { recursive: true });
 
 // where & how to store files
@@ -45,19 +41,56 @@ const allowedMimeTypes = [
   "audio/mp4",
 ];
 
+// Rejections carry a 400 so handleUploadError can tell a bad request apart
+// from a genuine server fault.
+export const rejectUpload = (message) => {
+  const err = new Error(message);
+  err.status = 400;
+  return err;
+};
+
 const fileFilter = (_req, file, cb) => {
   const ok = allowedMimeTypes.includes(file.mimetype);
 
   cb(
     ok
       ? null
-      : new Error("Only images, videos, audio, and PDF files are allowed"),
+      : rejectUpload("Only images, videos, audio, and PDF files are allowed"),
     ok,
   );
 };
 
+// Single source of truth for the upload size cap. Exported so every upload
+// route enforces the same limit instead of each one setting its own.
+export const MAX_UPLOAD_BYTES = 25 * 1024 * 1024; // 25MB
+
 export const upload = multer({
   storage,
   fileFilter,
-  limits: { fileSize: 25 * 1024 * 1024 }, // 25MB
+  limits: { fileSize: MAX_UPLOAD_BYTES },
 });
+
+/**
+ * Turn upload rejections into 400s.
+ *
+ * Multer surfaces an oversized file as a MulterError, and a rejected file type
+ * as whatever the fileFilter passed back. Without this they reach the global
+ * error handler and are reported as 500, which reads as a server fault when the
+ * request was the problem. Mount it immediately after the multer middleware on
+ * any route that accepts uploads.
+ */
+export const handleUploadError = (err, _req, res, next) => {
+  if (err instanceof multer.MulterError) {
+    const message =
+      err.code === "LIMIT_FILE_SIZE"
+        ? `File is too large. Maximum upload size is ${MAX_UPLOAD_BYTES / (1024 * 1024)}MB.`
+        : err.message;
+    return res.status(400).json({ error: message });
+  }
+
+  if (err?.status === 400) {
+    return res.status(400).json({ error: err.message });
+  }
+
+  return next(err);
+};

--- a/app-backend/src/config/uploadsDir.js
+++ b/app-backend/src/config/uploadsDir.js
@@ -1,0 +1,19 @@
+/**
+ * config/uploadsDir.js
+ *
+ * One definition of where uploaded files live, so writing and reading cannot
+ * drift apart.
+ *
+ * This deliberately avoids import.meta.url. Jest in this project cannot parse
+ * it, so any module importing a file that uses it fails to load in tests. The
+ * path is resolved from the working directory instead, which is the backend
+ * root both locally (npm start from app-backend) and in Docker (WORKDIR /app).
+ *
+ * Set UPLOADS_DIR to override, for example when running from another directory.
+ */
+
+import path from "path";
+
+export const uploadsDir = process.env.UPLOADS_DIR
+  ? path.resolve(process.env.UPLOADS_DIR)
+  : path.resolve(process.cwd(), "uploads");

--- a/app-backend/src/controllers/document.controller.js
+++ b/app-backend/src/controllers/document.controller.js
@@ -3,6 +3,7 @@ import {
   getDocumentById,
   updateDocumentExpiry,
   createDocument,
+  getDocumentFileForUser,
 } from "../services/document.service.js";
 
 /**
@@ -62,5 +63,28 @@ export const updateDocument = async (req, res) => {
     res.status(200).json(result);
   } catch (err) {
     res.status(400).json({ message: err.message });
+  }
+};
+
+/**
+ * GET /api/v1/documents/:id/file
+ *
+ * Send the file behind a document record. All rules live in the service, so
+ * this only turns the result into a response.
+ */
+export const downloadDocumentFile = async (req, res) => {
+  if (!req.user) {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+
+  try {
+    const file = await getDocumentFileForUser(req.params.id, req.user);
+    return res.download(file.path, file.filename);
+  } catch (err) {
+    if (err?.status) {
+      return res.status(err.status).json({ message: err.message });
+    }
+    console.error("Document file download error:", err);
+    return res.status(500).json({ message: "Server error" });
   }
 };

--- a/app-backend/src/controllers/incident.controller.js
+++ b/app-backend/src/controllers/incident.controller.js
@@ -275,14 +275,20 @@ export const uploadAttachment = async (req, res, next) => {
       return next(new ErrorResponse("No file uploaded", 400));
     }
 
-    incident.attachments.push({
+    // Build the subdocument first so it has an _id, then point fileUrl at the
+    // route that actually serves the file. It previously pointed at
+    // /uploads/<filename>, which nothing serves, so the URL always failed.
+    const attachment = incident.attachments.create({
       fileName: req.file.filename,
       originalName: req.file.originalname,
-      fileUrl: `/uploads/${req.file.filename}`,
+      fileUrl: "pending",
       mimeType: req.file.mimetype,
       fileSize: req.file.size,
       mediaType: getMediaType(req.file.mimetype),
     });
+
+    attachment.fileUrl = `/api/v1/incidents/${incident._id}/attachments/${attachment._id}`;
+    incident.attachments.push(attachment);
 
     await incident.save();
 

--- a/app-backend/src/routes/auth.routes.js
+++ b/app-backend/src/routes/auth.routes.js
@@ -2,7 +2,12 @@ import express from "express";
 import multer from "multer";
 import { MongoClient, GridFSBucket } from "mongodb";
 import path from "path";
-import { upload as imageUpload } from "../config/multer.js"; //
+import {
+  upload as imageUpload,
+  MAX_UPLOAD_BYTES,
+  handleUploadError,
+  rejectUpload,
+} from "../config/multer.js"; //
 import {
   register,
   registerGuardWithLicense,
@@ -86,11 +91,18 @@ router.post("/register", register);
  * @swagger
  * /api/v1/auth/register/guard:
  *   post:
- *     summary: Register a new Guard (requires license image)
+ *     summary: Register a new Guard (requires license file)
  *     description: |
- *       A unique email and a single licence image in the **license** form-data field are required.
- *       Supported image types are jpg, png, webp, and heic, with a maximum size of 5MB.
- *       The uploaded image is stored under `/uploads` and the initial licence status is **pending**.
+ *       A unique email and a single licence file in the **license** form-data field are required.
+ *
+ *       The backend currently accepts images (jpg, png, webp, heic), PDF, video
+ *       (mp4, mpeg, quicktime, webm) and audio (mpeg, wav, webm, mp4), up to
+ *       **25MB**. This documents the behaviour as implemented. Narrowing it to
+ *       images only would be a behavioural change and belongs in its own ticket.
+ *
+ *       The initial licence status is **pending**. The stored `imageUrl` is an
+ *       internal reference, not a URL you can request. Retrieve the file with
+ *       `GET /api/v1/documents/{id}/file`.
  *     tags: [Auth]
  *     requestBody:
  *       required: true
@@ -106,18 +118,21 @@ router.post("/register", register);
  *               license:
  *                 type: string
  *                 format: binary
- *                 description: License image file (jpg, png, webp, heic), max 5MB
+ *                 description: Licence file (image, PDF, video or audio), max 25MB
  *     responses:
  *       201:
  *         description: Guard registered; license uploaded (status = pending)
  *       400:
- *         description: Missing required fields or license image
+ *         description: |
+ *           Missing required fields, or the licence file was rejected because
+ *           its type is not accepted or it exceeds 25MB.
  *       500:
  *         description: Server error
  */
 router.post(
   "/register/guard",
   imageUpload.single("license"),
+  handleUploadError,
   registerGuardWithLicense,
 );
 
@@ -205,10 +220,16 @@ const storage = multer.memoryStorage(); // store files in memory temporarily
 const upload = multer({
   storage,
   fileFilter: (req, file, cb) => {
+    // Check the declared type as well as the extension. On its own an
+    // extension check passes any file simply renamed to ".pdf".
     const ext = path.extname(file.originalname).toLowerCase();
-    if (ext === ".pdf") cb(null, true);
-    else cb(new Error("Only PDF files are allowed"), false);
+    const ok = ext === ".pdf" && file.mimetype === "application/pdf";
+    if (ok) cb(null, true);
+    else cb(rejectUpload("Only PDF files are allowed"), false);
   },
+  // These files are buffered in memory, so an unbounded upload would be held
+  // in RAM in full. Same cap as the disk uploads in config/multer.js.
+  limits: { fileSize: MAX_UPLOAD_BYTES },
 });
 
 // ---------------- MongoDB GridFS Setup ----------------
@@ -263,7 +284,10 @@ if (process.env.NODE_ENV !== "test") {
  *                 items:
  *                   type: string
  *                   format: binary
- *                 description: Up to 5 PDF files
+ *                 description: |
+ *                   Up to 5 PDF files, each a maximum of 25MB. A file is only
+ *                   accepted when both its extension and its content type are
+ *                   PDF. Documents are stored in the eoiDocuments GridFS bucket.
  *     responses:
  *       201:
  *         description: EOI submitted successfully
@@ -287,67 +311,74 @@ if (process.env.NODE_ENV !== "test") {
  *                         type: string
  *                         example: 64f1c6a3b5e18f9b9a3d52f77
  *       400:
- *         description: No documents uploaded
+ *         description: |
+ *           No documents uploaded, or a file was rejected because it is not a
+ *           PDF or exceeds 25MB.
  *       500:
  *         description: Server error while uploading EOI
  */
 
 // ---------------- EOI Route ----------------
-router.post("/eoi", upload.array("documents", 5), async (req, res) => {
-  try {
-    if (!req.files || req.files.length === 0) {
-      return res.status(400).json({ error: "No documents uploaded" });
-    }
+router.post(
+  "/eoi",
+  upload.array("documents", 5),
+  handleUploadError,
+  async (req, res) => {
+    try {
+      if (!req.files || req.files.length === 0) {
+        return res.status(400).json({ error: "No documents uploaded" });
+      }
 
-    // store each file in GridFS
-    const fileInfos = await Promise.all(
-      req.files.map((file) => {
-        return new Promise((resolve, reject) => {
-          const uploadStream = gridFSBucket.openUploadStream(
-            file.originalname,
-            {
-              contentType: file.mimetype, // use actual mimetype
-            },
-          );
+      // store each file in GridFS
+      const fileInfos = await Promise.all(
+        req.files.map((file) => {
+          return new Promise((resolve, reject) => {
+            const uploadStream = gridFSBucket.openUploadStream(
+              file.originalname,
+              {
+                contentType: file.mimetype, // use actual mimetype
+              },
+            );
 
-          uploadStream.end(file.buffer);
-          uploadStream.on("finish", () => {
-            resolve({
-              filename: uploadStream.filename,
-              id: uploadStream.id,
+            uploadStream.end(file.buffer);
+            uploadStream.on("finish", () => {
+              resolve({
+                filename: uploadStream.filename,
+                id: uploadStream.id,
+              });
             });
+            uploadStream.on("error", reject);
           });
-          uploadStream.on("error", reject);
-        });
-      }),
-    );
+        }),
+      );
 
-    // You can also save other EOI info in MongoDB collection
-    const eoiData = {
-      companyName: req.body.companyName,
-      abnAcn: req.body.abnAcn,
-      contactPerson: req.body.contactPerson,
-      contactEmail: req.body.contactEmail,
-      phone: req.body.phone,
-      description: req.body.description,
-      documents: fileInfos,
-      createdAt: new Date(),
-    };
+      // You can also save other EOI info in MongoDB collection
+      const eoiData = {
+        companyName: req.body.companyName,
+        abnAcn: req.body.abnAcn,
+        contactPerson: req.body.contactPerson,
+        contactEmail: req.body.contactEmail,
+        phone: req.body.phone,
+        description: req.body.description,
+        documents: fileInfos,
+        createdAt: new Date(),
+      };
 
-    // Use your submitEOI controller to store eoiData in a collection
-    const { employerCreated } = await submitEOI(eoiData);
+      // Use your submitEOI controller to store eoiData in a collection
+      const { employerCreated } = await submitEOI(eoiData);
 
-    let message = "EOI submitted successfully";
-    if (!employerCreated) {
-      message +=
-        " (Account already exists for this email; no new credentials sent)";
+      let message = "EOI submitted successfully";
+      if (!employerCreated) {
+        message +=
+          " (Account already exists for this email; no new credentials sent)";
+      }
+
+      res.status(201).json({ message, files: fileInfos });
+    } catch (err) {
+      console.error("EOI upload error:", err);
+      res.status(500).json({ error: err.message });
     }
-
-    res.status(201).json({ message, files: fileInfos });
-  } catch (err) {
-    console.error("EOI upload error:", err);
-    res.status(500).json({ error: err.message });
-  }
-});
+  },
+);
 
 export default router;

--- a/app-backend/src/routes/document.routes.js
+++ b/app-backend/src/routes/document.routes.js
@@ -6,6 +6,7 @@ import {
   getDocuments,
   getSingleDocument,
   updateDocument,
+  downloadDocumentFile,
 } from "../controllers/document.controller.js";
 
 const router = express.Router();
@@ -160,4 +161,48 @@ router.post(
   authorizeRoles("admin", "employer"),
   addDocument,
 );
+/**
+ * @swagger
+ * /api/v1/documents/{id}/file:
+ *   get:
+ *     summary: Download the file attached to a document
+ *     description: |
+ *       Returns the uploaded file itself, for example a guard's licence image.
+ *
+ *       Access follows least privilege. A guard may retrieve their own
+ *       documents and an admin may retrieve anyone's. Employers are not granted
+ *       licence access, because the current model has no reliable guard to
+ *       employer relationship to check against.
+ *
+ *       The `imageUrl` field on a document is a stored reference, not a URL you
+ *       can request. Use this endpoint to fetch the file.
+ *     tags: [Documents]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The document id
+ *     responses:
+ *       200:
+ *         description: The file
+ *         content:
+ *           application/octet-stream:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       401:
+ *         description: No valid token supplied
+ *       403:
+ *         description: Authenticated, but not permitted to retrieve this document
+ *       404:
+ *         description: No such document, or the record exists but its file is missing
+ */
+// Registered after the literal "/admin/..." paths above so those are matched
+// first rather than being read as an id.
+router.get("/:id/file", auth, downloadDocumentFile);
+
 export default router;

--- a/app-backend/src/routes/incident.routes.js
+++ b/app-backend/src/routes/incident.routes.js
@@ -247,7 +247,12 @@ router.delete("/:id", authorizePermissions("incident:delete"), deleteIncident);
  *     description: |
  *       Upload a supported file and attach it to an existing incident.
  *
- *       Supported files: images, videos, audio, and PDFs.
+ *       Supported files: images, videos, audio and PDFs, up to 25MB.
+ *
+ *       The `fileUrl` returned on each attachment points at the retrieval
+ *       endpoint below, `GET /api/v1/incidents/{id}/attachments/{attachmentId}`.
+ *       It previously pointed at `/uploads/<filename>`, which nothing serves,
+ *       so that URL always failed.
  *     tags: [Incidents]
  *     security:
  *       - bearerAuth: []

--- a/app-backend/src/services/document.service.js
+++ b/app-backend/src/services/document.service.js
@@ -1,4 +1,8 @@
+import fs from "fs";
+import path from "path";
+import mongoose from "mongoose";
 import User from "../models/User.js";
+import { resolveUploadPath } from "../utils/uploadPath.js";
 // CREATE DOCUMENT
 export const createDocument = async (data, user) => {
   const { userId, type, expiryDate, imageUrl } = data;
@@ -83,7 +87,15 @@ export const getAllDocuments = async (query) => {
 
 //  Get single document
 export const getDocumentById = async (docId) => {
-  const user = await User.findOne({ "documents._id": docId });
+  // Cast explicitly, see the note in getDocumentFileForUser. Without this the
+  // query never matches and every lookup returns "Document not found".
+  if (!mongoose.Types.ObjectId.isValid(docId)) {
+    throw new Error("Document not found");
+  }
+
+  const user = await User.findOne({
+    "documents._id": new mongoose.Types.ObjectId(docId),
+  });
 
   if (!user) throw new Error("Document not found");
 
@@ -110,7 +122,14 @@ export const updateDocumentExpiry = async (docId, expiryDate, user) => {
     throw new Error("Invalid expiry date");
   }
 
-  const targetUser = await User.findOne({ "documents._id": docId });
+  // Same casting issue as getDocumentById.
+  if (!mongoose.Types.ObjectId.isValid(docId)) {
+    throw new Error("Document not found");
+  }
+
+  const targetUser = await User.findOne({
+    "documents._id": new mongoose.Types.ObjectId(docId),
+  });
 
   if (!targetUser) throw new Error("Document not found");
 
@@ -127,4 +146,64 @@ export const updateDocumentExpiry = async (docId, expiryDate, user) => {
   await targetUser.save();
 
   return { message: "Document expiry updated successfully" };
+};
+
+/**
+ * Locate the file behind a document and confirm the caller may have it.
+ *
+ * Access follows the least privilege rules agreed for BE 028:
+ *   - a guard may retrieve their own documents
+ *   - an admin may retrieve anyone's
+ *   - employers are not granted licence access, because there is no reliable
+ *     guard to employer link in the current model. Shift offers applicants,
+ *     acceptedBy and guardIds, which mean three different things, so choosing
+ *     one would be a product decision rather than an implementation detail.
+ *
+ * Errors carry a status for the controller to surface:
+ *   403 the caller is authenticated but not allowed this document
+ *   404 no such document, or the record exists but its file is gone
+ *
+ * @param {string} docId
+ * @param {{ id: string, role: string }} requester from req.user
+ * @returns {Promise<{ path: string, filename: string }>}
+ */
+export const getDocumentFileForUser = async (docId, requester) => {
+  const httpError = (status, message) => {
+    const err = new Error(message);
+    err.status = status;
+    return err;
+  };
+
+  if (!mongoose.Types.ObjectId.isValid(docId)) {
+    throw httpError(404, "Document not found");
+  }
+
+  // Cast explicitly. "documents" is declared on the Guard discriminator rather
+  // than the base User schema, so Mongoose cannot resolve the path to cast the
+  // string itself and the query would silently match nothing.
+  const owner = await User.findOne({
+    "documents._id": new mongoose.Types.ObjectId(docId),
+  });
+  if (!owner) throw httpError(404, "Document not found");
+
+  const requesterId = String(requester?.id || requester?._id || "");
+  const isOwner = String(owner._id) === requesterId;
+  const isAdmin = requester?.role === "admin";
+
+  // Lou's spec for this ticket: authenticated but not permitted is a 403, not
+  // a 404. That is deliberate here even though the availability endpoints hide
+  // existence behind a 404.
+  if (!isOwner && !isAdmin) {
+    throw httpError(403, "Not authorized to retrieve this document");
+  }
+
+  const doc = owner.documents.id(docId);
+  if (!doc) throw httpError(404, "Document not found");
+
+  const resolved = resolveUploadPath(doc.imageUrl);
+  if (!resolved || !fs.existsSync(resolved)) {
+    throw httpError(404, "Document file not found");
+  }
+
+  return { path: resolved, filename: path.basename(resolved) };
 };

--- a/app-backend/src/utils/uploadPath.js
+++ b/app-backend/src/utils/uploadPath.js
@@ -1,0 +1,56 @@
+/**
+ * utils/uploadPath.js
+ *
+ * Resolves a stored upload reference to a real path on disk.
+ *
+ * Values recorded against uploads are not consistent. Guard licences store
+ * "/uploads/<filename>" in imageUrl, while incident attachments store a bare
+ * filename. Both end up in the same directory, so retrieval has to cope with
+ * either form.
+ *
+ * These values come out of the database, but they originate from user supplied
+ * filenames, so they are treated as untrusted. A value containing "../" must
+ * never be able to reach a file outside the uploads directory.
+ */
+
+import fs from "fs";
+import path from "path";
+import { uploadsDir } from "../config/uploadsDir.js";
+
+/**
+ * Turn a stored reference into an absolute path inside the uploads directory.
+ * Returns null when the value is unusable or points outside that directory.
+ *
+ * @param {string} stored e.g. "/uploads/1712-licence.png" or "1712-licence.png"
+ * @returns {string|null}
+ */
+export const resolveUploadPath = (stored) => {
+  if (typeof stored !== "string" || stored.trim() === "") return null;
+
+  // Keep only the final path segment. This alone defeats "../" traversal,
+  // because path.basename("../../etc/passwd") is "passwd".
+  const filename = path.basename(stored.trim());
+
+  // basename can still return something unusable for these inputs.
+  if (!filename || filename === "." || filename === "..") return null;
+
+  const resolved = path.resolve(uploadsDir, filename);
+
+  // Second check in case basename is ever removed or changed above. The
+  // resolved path must sit directly inside the uploads directory.
+  if (path.dirname(resolved) !== path.resolve(uploadsDir)) return null;
+
+  return resolved;
+};
+
+/**
+ * True when the stored reference resolves to a file that exists on disk.
+ * A record can outlive its file, so callers need to tell those cases apart.
+ *
+ * @param {string} stored
+ * @returns {boolean}
+ */
+export const uploadExists = (stored) => {
+  const resolved = resolveUploadPath(stored);
+  return resolved !== null && fs.existsSync(resolved);
+};

--- a/app-backend/tests/documentFile.controller.test.js
+++ b/app-backend/tests/documentFile.controller.test.js
@@ -1,0 +1,215 @@
+import mongoose from "mongoose";
+import fs from "fs";
+
+import { downloadDocumentFile } from "../src/controllers/document.controller.js";
+import User from "../src/models/User.js";
+import { resolveUploadPath, uploadExists } from "../src/utils/uploadPath.js";
+import { uploadsDir } from "../src/config/uploadsDir.js";
+
+// Replace the model's DB call and the filesystem check so the tests never touch
+// Mongo or the real uploads folder.
+jest.mock("../src/models/User.js", () => ({
+  __esModule: true,
+  default: { findOne: jest.fn() },
+}));
+
+jest.mock("fs", () => ({
+  __esModule: true,
+  default: { existsSync: jest.fn() },
+  existsSync: jest.fn(),
+}));
+
+const OWNER_ID = new mongoose.Types.ObjectId().toString();
+const OTHER_ID = new mongoose.Types.ObjectId().toString();
+const ADMIN_ID = new mongoose.Types.ObjectId().toString();
+const EMPLOYER_ID = new mongoose.Types.ObjectId().toString();
+const DOC_ID = new mongoose.Types.ObjectId().toString();
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnThis();
+  res.json = jest.fn();
+  res.download = jest.fn();
+  return res;
+};
+
+const mockReq = (overrides = {}) => ({
+  user: { id: OWNER_ID, _id: OWNER_ID, role: "guard" },
+  params: { id: DOC_ID },
+  ...overrides,
+});
+
+// A user document holding one embedded document record, shaped the way
+// Mongoose returns it (documents.id(...) looks up a subdocument by id).
+const mockOwner = (imageUrl = "/uploads/licence.png", ownerId = OWNER_ID) => ({
+  _id: ownerId,
+  documents: {
+    id: jest.fn().mockReturnValue(imageUrl ? { _id: DOC_ID, imageUrl } : null),
+  },
+});
+
+describe("Upload path resolution", () => {
+  test("resolves a bare filename inside the uploads directory", () => {
+    const resolved = resolveUploadPath("licence.png");
+    expect(resolved).toBe(`${uploadsDir}/licence.png`);
+  });
+
+  test("resolves a stored /uploads/ reference to the same place", () => {
+    expect(resolveUploadPath("/uploads/licence.png")).toBe(
+      `${uploadsDir}/licence.png`,
+    );
+  });
+
+  test("refuses a path traversal attempt", () => {
+    // basename strips the traversal, so this must not escape the folder.
+    const resolved = resolveUploadPath("../../../../etc/passwd");
+    expect(resolved).toBe(`${uploadsDir}/passwd`);
+    expect(resolved).not.toContain("etc/passwd");
+  });
+
+  test("returns null for values that cannot be a filename", () => {
+    expect(resolveUploadPath("")).toBeNull();
+    expect(resolveUploadPath("   ")).toBeNull();
+    expect(resolveUploadPath(null)).toBeNull();
+    expect(resolveUploadPath(undefined)).toBeNull();
+    expect(resolveUploadPath(123)).toBeNull();
+    expect(resolveUploadPath("..")).toBeNull();
+  });
+
+  test("uploadExists is false when the file is not on disk", () => {
+    fs.existsSync.mockReturnValue(false);
+    expect(uploadExists("/uploads/licence.png")).toBe(false);
+  });
+});
+
+describe("downloadDocumentFile", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fs.existsSync.mockReturnValue(true);
+  });
+
+  test("401 when there is no authenticated user", async () => {
+    const req = mockReq({ user: undefined });
+    const res = mockRes();
+
+    await downloadDocumentFile(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.download).not.toHaveBeenCalled();
+  });
+
+  test("404 when the document id is not a valid ObjectId", async () => {
+    const req = mockReq({ params: { id: "not-an-id" } });
+    const res = mockRes();
+
+    await downloadDocumentFile(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(User.findOne).not.toHaveBeenCalled();
+  });
+
+  test("404 when no document matches the id", async () => {
+    User.findOne.mockResolvedValue(null);
+    const res = mockRes();
+
+    await downloadDocumentFile(mockReq(), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.download).not.toHaveBeenCalled();
+  });
+
+  test("looks the document up by ObjectId, not by string", async () => {
+    // documents is declared on the Guard discriminator rather than the base
+    // User schema, so Mongoose cannot cast the string itself and the query
+    // would match nothing.
+    User.findOne.mockResolvedValue(mockOwner());
+
+    await downloadDocumentFile(mockReq(), mockRes());
+
+    const query = User.findOne.mock.calls[0][0];
+    expect(query["documents._id"]).toBeInstanceOf(mongoose.Types.ObjectId);
+  });
+
+  test("403 when the document belongs to another user", async () => {
+    User.findOne.mockResolvedValue(mockOwner("/uploads/licence.png", OTHER_ID));
+    const res = mockRes();
+
+    await downloadDocumentFile(mockReq(), res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.download).not.toHaveBeenCalled();
+  });
+
+  test("200 and sends the file to the owner", async () => {
+    User.findOne.mockResolvedValue(mockOwner());
+    const res = mockRes();
+
+    await downloadDocumentFile(mockReq(), res);
+
+    expect(res.download).toHaveBeenCalledWith(
+      `${uploadsDir}/licence.png`,
+      "licence.png",
+    );
+    expect(res.status).not.toHaveBeenCalledWith(403);
+  });
+
+  test("200 and sends the file to an admin for someone else's document", async () => {
+    User.findOne.mockResolvedValue(mockOwner("/uploads/licence.png", OTHER_ID));
+    const req = mockReq({
+      user: { id: ADMIN_ID, _id: ADMIN_ID, role: "admin" },
+    });
+    const res = mockRes();
+
+    await downloadDocumentFile(req, res);
+
+    expect(res.download).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalledWith(403);
+  });
+
+  test("403 for an employer, licence access is out of scope for BE 028", async () => {
+    User.findOne.mockResolvedValue(mockOwner("/uploads/licence.png", OTHER_ID));
+    const req = mockReq({
+      user: { id: EMPLOYER_ID, _id: EMPLOYER_ID, role: "employer" },
+    });
+    const res = mockRes();
+
+    await downloadDocumentFile(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.download).not.toHaveBeenCalled();
+  });
+
+  test("404 when the record exists but its file is missing from disk", async () => {
+    User.findOne.mockResolvedValue(mockOwner());
+    fs.existsSync.mockReturnValue(false);
+    const res = mockRes();
+
+    await downloadDocumentFile(mockReq(), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.download).not.toHaveBeenCalled();
+  });
+
+  test("404 when the document record has no file reference at all", async () => {
+    User.findOne.mockResolvedValue(mockOwner(null));
+    const res = mockRes();
+
+    await downloadDocumentFile(mockReq(), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.download).not.toHaveBeenCalled();
+  });
+
+  test("a traversal value in the database cannot reach outside the uploads folder", async () => {
+    User.findOne.mockResolvedValue(mockOwner("../../../../etc/passwd"));
+    const res = mockRes();
+
+    await downloadDocumentFile(mockReq(), res);
+
+    // It resolves to <uploads>/passwd, which does not exist, so it 404s
+    // rather than serving a file from elsewhere on the server.
+    const sent = res.download.mock.calls[0]?.[0];
+    if (sent) expect(sent.startsWith(uploadsDir)).toBe(true);
+    expect(sent).not.toBe("/etc/passwd");
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       mailpit:
         condition: service_healthy
     restart: unless-stopped
+    volumes:
+      # Keep uploaded licence and incident files across container rebuilds.
+      # Without this the container filesystem is discarded and every upload is lost.
+      - uploads-data:/app/uploads
     networks:
       - secureshift
     command: npm start
@@ -86,6 +90,7 @@ services:
 
 volumes:
   mongo-data:
+  uploads-data:
 
 networks:
   secureshift:


### PR DESCRIPTION
## Summary

Implements **BE 028, Make Uploaded Licence and Incident Files Retrievable and Persistent**.

Uploaded files were written to disk but there was no way to fetch them back, and they were lost whenever the backend container was rebuilt. One upload path also had no size limit at all.

All seven checklist items on the ticket are covered.

## What changed

**Persistence.** Added a named docker volume for the uploads directory so files survive container rebuilds. Previously the container filesystem was discarded on rebuild and every uploaded file went with it.

**Retrieval.** Added `GET /api/v1/documents/:id/file`, which returns the file behind a document record, for example a guard's licence image.

**Safe path handling.** Stored file references are resolved through `utils/uploadPath.js`, which keeps the final path inside the uploads directory. A stored value containing `../` cannot reach other files on the server.

**Incident file URLs.** Uploading an incident attachment returned `fileUrl: /uploads/<filename>`, which nothing serves, so the URL always failed. It now points at `GET /api/v1/incidents/{id}/attachments/{attachmentId}`, which is the route that actually serves the file.

**Upload limits.** The EOI upload had no size limit and buffered whole files in memory. It is now capped at 25MB to match the disk uploads, and checks the content type as well as the file extension, since an extension check alone passes anything renamed to `.pdf`. The limit now lives in one exported constant so the two upload paths cannot drift apart again.

**Error codes.** Upload rejections were reaching the global handler and being reported as 500. They now return 400 with the reason, including the size limit in the message.

## Access rules

As agreed with @LoopyB, least privilege:

| Caller | Licence file |
|---|---|
| The guard it belongs to | allowed |
| Admin | allowed |
| Anyone else | 403 |

Status codes are 401 unauthenticated, 403 authenticated but not permitted, 404 for a missing record or a record whose file is gone.

Note this is deliberately different from the availability endpoints in #449, which return 404 rather than 403 to avoid confirming a record exists. 403 here follows the spec agreed for this ticket rather than that earlier pattern.

## Decisions worth recording

**Employer licence access is out of scope**, as agreed. There is no reliable way to establish a guard to employer relationship in the current model. `Shift` offers `applicants`, `acceptedBy` and `guardIds`, which mean applied for, accepted, and assigned. Those are three different things, and choosing which one grants access to somebody's licence document is an access policy decision rather than an implementation detail. Employer access to incident attachments is kept, because `incident.shiftId` to `Shift.createdBy` is an explicit single relationship and the existing route already enforces it.

**Guard registration Swagger discrepancy.** The documentation said images only with a 5MB limit. The code accepts images, PDF, video and audio up to 25MB. On @LoopyB's direction I aligned the documentation to the implemented behaviour rather than tightening the code, since restricting the accepted types or size would be a behavioural change and belongs in its own ticket. The Swagger now describes what the endpoint actually does, and says as much.

## Found while working on this

Three things outside the strict scope of the ticket. Happy to split any of them out if you would rather.

**1. A query bug that had broken two existing endpoints.** `getDocumentById` and the expiry update both ran `User.findOne({ "documents._id": docId })` with a string. `documents` is declared on the `Guard` discriminator rather than the base `User` schema, so Mongoose cannot resolve the path to cast it and the query silently matched nothing. Both endpoints returned "Document not found" for documents that exist. Confirmed directly in the database, where the query matches by ObjectId and returns zero by string. Fixed with an explicit cast, and `GET /documents/admin/documents/:id` now returns real data instead of 404.

**2. The EOI upload had no size limit**, covered above. Included here because it was a memory risk rather than a correctness one.

**3. Seeded role permissions are a stale subset of the code defaults.** Not fixed in this PR, flagging only. The `Role` documents in the database carry far fewer permissions than `DEFAULT_ROLE_PERMISSIONS` in `middleware/rbac.js`:

```
DB   admin -> user:read, user:write, shift:read, shift:write, shift:assign
DB   guard -> shift:read, shift:accept, shift:checkin

code admin -> also incident:create / view / update / delete
code guard -> also incident:create / view / update
```

`authorizePermissions` reads the database row first and only falls back to the code map when no row exists, so the smaller list wins. The effect is that in a seeded environment nobody except `super_admin` can use an incident permission gated route, including uploading an incident attachment. I hit this while testing. It looks like the same class of role definition drift already noted in the architecture doc.

## Testing

**Unit tests.** 16 new tests in `tests/documentFile.controller.test.js`, covering path resolution and every access rule.

```
Upload path resolution
  resolves a bare filename inside the uploads directory
  resolves a stored /uploads/ reference to the same place
  refuses a path traversal attempt
  returns null for values that cannot be a filename
  uploadExists is false when the file is not on disk
downloadDocumentFile
  401 when there is no authenticated user
  404 when the document id is not a valid ObjectId
  404 when no document matches the id
  looks the document up by ObjectId, not by string
  403 when the document belongs to another user
  200 and sends the file to the owner
  200 and sends the file to an admin for someone else's document
  403 for an employer, licence access is out of scope for BE 028
  404 when the record exists but its file is missing from disk
  404 when the document record has no file reference at all
  a traversal value in the database cannot reach outside the uploads folder

Tests: 16 passed, 16 total
```

Full suite compared against `main` with and without this branch, to confirm nothing regressed:

```
main alone:   11 failed suites, 22 passed, 221 tests passed
this branch:  11 failed suites, 23 passed, 237 tests passed
```

Same eleven pre-existing suite failures on both, plus this branch's suite and its 16 tests. Lint and `format:check` are clean.

**Live checks** against the running stack, authenticated as the seeded guard, a second guard, and an admin:

```
owner fetches own licence      200 + file contents
different guard                403
admin fetches it               200 + file contents
no token                       401
document does not exist        404
record exists, file deleted    404
imageUrl set to ../../etc/passwd   404, nothing served
```

**Incident URL, end to end.** Uploaded an attachment, took the returned URL from the response and requested it:

```
fileUrl : /api/v1/incidents/6a7c4028.../attachments/6a7c40a9...
GET that URL -> 200, file contents returned
```

**Persistence.** Wrote a file into the uploads volume, destroyed the backend container with `docker compose rm -sf backend`, recreated it, and the file was still there.

## Notes

- Rebased onto current `main`. There was a conflict in `config/multer.js` because the uploads directory was moved to `<backend root>/uploads` and the `import.meta.url` usage removed. I took that location and kept it in one shared module so writing and reading cannot drift apart. All checks above were re-run after the rebase.
- No existing behaviour was changed other than the two fixes described, and the incident `fileUrl` value, which previously pointed at a path nothing serves and is not read by either client.
